### PR TITLE
RFC: debug.id

### DIFF
--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -12,7 +12,7 @@ When debugging, it is often useful to compare identity. Usually `print` will pri
 
 ## Design
 
-`debug.id(value: string | userdata | table | thread | function): number` always returns the identifier unique to that value, and is not possible to override. The identifier can be reused after the value associated with it is garbage collected.
+`debug.id(value: string | userdata | table | thread | function): string` always returns the identifier unique to that value, and is not possible to override. The identifier can be reused after the value associated with it is garbage collected.
 
 While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
 

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -12,7 +12,7 @@ When debugging, it is often useful to compare identity. Usually `print` will pri
 
 ## Design
 
-`debug.id(value: any)` always returns the identifier unique to that value, and is not possible to override.
+`debug.id(value: any): number` always returns the identifier unique to that value, and is not possible to override.
 
 While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
 

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `debug.id` which accepts a value and always returns the identifier unique to that value.
+Add `debug.id` which accepts a value and always returns the identifier unique to all values that haven't been garbage collected.
 
 ## Motivation
 
@@ -12,7 +12,7 @@ When debugging, it is often useful to compare identity. Usually `print` will pri
 
 ## Design
 
-`debug.id(value: string | userdata | table | thread | function): number` always returns the identifier unique to that value, and is not possible to override.
+`debug.id(value: string | userdata | table | thread | function): number` always returns the identifier unique to that value, and is not possible to override. Uniqueness is only guaranteed for values that haven't been garbage collected.
 
 While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
 

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -14,8 +14,6 @@ When debugging, it is often useful to compare identity. Usually `print` will pri
 
 `debug.id(value: string | userdata | table | thread | function): string` always returns the identifier unique to that value, and is not possible to override. The identifier can be reused after the value associated with it is garbage collected.
 
-While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
-
 ## Drawbacks
 
 Identifiers being reused has the potential to confuse humans reading them.

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -18,7 +18,7 @@ While tables and userdata have individualized metatables, also allowing function
 
 ## Drawbacks
 
-None known.
+Identifiers being reused has the potential to confuse humans reading them.
 
 ## Alternatives
 

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -1,0 +1,27 @@
+# `debug.id`
+
+## Summary
+
+Add `debug.id` which accepts a value and always returns the identifier unique to that value.
+
+## Motivation
+
+When debugging, it is often useful to compare identity. Usually `print` will print the memory address of the table or userdata, but when `__tostring` is overriden, the address becomes unobtainable.
+
+`rawequal` can compare equality between two arguments, but is not suitable for a human comparing output between two `print` calls or between keys or values in a table.
+
+## Design
+
+`debug.id(value: any)` always returns the identifier unique to that value, and is not possible to override.
+
+While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
+
+## Drawbacks
+
+None known.
+
+## Alternatives
+
+Lua has `string.format("%p", {})`, but this is an invalid format option in Luau and less obvious.
+
+If not implemented, it remains annoying to compare identity when dealing with tables or userdata that override `__tostring`.

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `debug.id` which accepts a value and always returns the identifier unique to all values that haven't been garbage collected.
+Add `debug.id` which accepts a value and always returns the identifier unique to that value.
 
 ## Motivation
 
@@ -12,7 +12,7 @@ When debugging, it is often useful to compare identity. Usually `print` will pri
 
 ## Design
 
-`debug.id(value: string | userdata | table | thread | function): number` always returns the identifier unique to that value, and is not possible to override. Uniqueness is only guaranteed for values that haven't been garbage collected.
+`debug.id(value: string | userdata | table | thread | function): number` always returns the identifier unique to that value, and is not possible to override. The identifier can be reused after the value associated with it is garbage collected.
 
 While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
 

--- a/rfcs/function-debug-id.md
+++ b/rfcs/function-debug-id.md
@@ -12,7 +12,7 @@ When debugging, it is often useful to compare identity. Usually `print` will pri
 
 ## Design
 
-`debug.id(value: any): number` always returns the identifier unique to that value, and is not possible to override.
+`debug.id(value: string | userdata | table | thread | function): number` always returns the identifier unique to that value, and is not possible to override.
 
 While tables and userdata have individualized metatables, also allowing functions and threads to be passed to `debug.id` would let their type-level `__tostring` be redefined. Strings are useful to accept because of long, similar strings.
 


### PR DESCRIPTION
[Rendered link](https://github.com/Qualadore/luau/blob/rfc-function-debug-id/rfcs/function-debug-id.md)

Identifier returned could also easily be a string depending on implementation.