### PR TITLE
TypePairHash.h: include cstdint

### DIFF
--- a/Analysis/include/Luau/TypePairHash.h
+++ b/Analysis/include/Luau/TypePairHash.h
@@ -3,6 +3,8 @@
 
 #include "Luau/TypeFwd.h"
 
+#include <stdint.h>
+
 #include <utility>
 
 namespace Luau


### PR DESCRIPTION
luau fails to compile w/o this on Gentoo