### PR TITLE
Optimize vector literals by storing them in the constant table

### DIFF
--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -426,8 +426,8 @@ enum LuauBytecodeTag
 {
     // Bytecode version; runtime supports [MIN, MAX], compiler emits TARGET by default but may emit a higher version when flags are enabled
     LBC_VERSION_MIN = 3,
-    LBC_VERSION_MAX = 4,
-    LBC_VERSION_TARGET = 4,
+    LBC_VERSION_MAX = 5,
+    LBC_VERSION_TARGET = 5,
     // Type encoding version
     LBC_TYPE_VERSION = 1,
     // Types of constant table entries
@@ -438,6 +438,7 @@ enum LuauBytecodeTag
     LBC_CONSTANT_IMPORT,
     LBC_CONSTANT_TABLE,
     LBC_CONSTANT_CLOSURE,
+    LBC_CONSTANT_VECTOR,
 };
 
 // Type table tags

--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -70,7 +70,7 @@ enum LuauOpcode
     // D: value (-32768..32767)
     LOP_LOADN,
 
-    // LOADK: sets register to an entry from the constant table from the proto (number/string)
+    // LOADK: sets register to an entry from the constant table from the proto (number/vector/string)
     // A: target register
     // D: constant table index (0..32767)
     LOP_LOADK,

--- a/Compiler/include/Luau/BytecodeBuilder.h
+++ b/Compiler/include/Luau/BytecodeBuilder.h
@@ -54,7 +54,7 @@ public:
     int32_t addConstantNil();
     int32_t addConstantBoolean(bool value);
     int32_t addConstantNumber(double value);
-    int32_t addConstantVector(double x, double y, double z);
+    int32_t addConstantVector(float x, float y, float z);
     int32_t addConstantString(StringRef value);
     int32_t addImport(uint32_t iid);
     int32_t addConstantTable(const TableShape& shape);

--- a/Compiler/include/Luau/BytecodeBuilder.h
+++ b/Compiler/include/Luau/BytecodeBuilder.h
@@ -158,7 +158,7 @@ private:
         {
             bool valueBoolean;
             double valueNumber;
-            float valueVector[ 3 ];
+            float valueVector[3];
             unsigned int valueString; // index into string table
             uint32_t valueImport;     // 10-10-10-2 encoded import id
             uint32_t valueTable;      // index into tableShapes[]

--- a/Compiler/include/Luau/BytecodeBuilder.h
+++ b/Compiler/include/Luau/BytecodeBuilder.h
@@ -54,6 +54,7 @@ public:
     int32_t addConstantNil();
     int32_t addConstantBoolean(bool value);
     int32_t addConstantNumber(double value);
+    int32_t addConstantVector(double x, double y, double z);
     int32_t addConstantString(StringRef value);
     int32_t addImport(uint32_t iid);
     int32_t addConstantTable(const TableShape& shape);
@@ -145,6 +146,7 @@ private:
             Type_Nil,
             Type_Boolean,
             Type_Number,
+            Type_Vector,
             Type_String,
             Type_Import,
             Type_Table,
@@ -156,6 +158,7 @@ private:
         {
             bool valueBoolean;
             double valueNumber;
+            float valueVector[ 3 ];
             unsigned int valueString; // index into string table
             uint32_t valueImport;     // 10-10-10-2 encoded import id
             uint32_t valueTable;      // index into tableShapes[]
@@ -166,12 +169,14 @@ private:
     struct ConstantKey
     {
         Constant::Type type;
-        // Note: this stores value* from Constant; when type is Number_Double, this stores the same bits as double does but in uint64_t.
+        // Note: this stores value* from Constant; when type is Type_Number, this stores the same bits as double does but in uint64_t.
+        // for Type_Vector, x and y are stored in value and z is stored in extra.
         uint64_t value;
+        uint32_t extra = 0;
 
         bool operator==(const ConstantKey& key) const
         {
-            return type == key.type && value == key.value;
+            return type == key.type && value == key.value && extra == key.extra;
         }
     };
 

--- a/Compiler/src/BuiltinFolding.cpp
+++ b/Compiler/src/BuiltinFolding.cpp
@@ -32,6 +32,15 @@ static Constant cnum(double v)
     return res;
 }
 
+static Constant cvector(double x, double y, double z)
+{
+    Constant res = {Constant::Type_Vector};
+    res.valueVector[0] = (float)x;
+    res.valueVector[1] = (float)y;
+    res.valueVector[2] = (float)z;
+    return res;
+}
+
 static Constant cstring(const char* v)
 {
     Constant res = {Constant::Type_String};
@@ -455,6 +464,11 @@ Constant foldBuiltin(int bfid, const Constant* args, size_t count)
     case LBF_MATH_ROUND:
         if (count == 1 && args[0].type == Constant::Type_Number)
             return cnum(round(args[0].valueNumber));
+        break;
+
+    case LBF_VECTOR:
+        if (count == 3 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number && args[2].type == Constant::Type_Number)
+            return cvector(args[0].valueNumber, args[1].valueNumber, args[2].valueNumber);
         break;
     }
 

--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -1681,6 +1681,9 @@ void BytecodeBuilder::dumpConstant(std::string& result, int k) const
     case Constant::Type_Number:
         formatAppend(result, "%.17g", data.valueNumber);
         break;
+    case Constant::Type_Vector:
+        formatAppend(result, "%.17g, %.17g, %.17g", data.valueVector[0], data.valueVector[1], data.valueVector[2]);
+        break;
     case Constant::Type_String:
     {
         const StringRef& str = debugStrings[data.valueString - 1];

--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -1682,7 +1682,7 @@ void BytecodeBuilder::dumpConstant(std::string& result, int k) const
         formatAppend(result, "%.17g", data.valueNumber);
         break;
     case Constant::Type_Vector:
-        formatAppend(result, "%.17g, %.17g, %.17g", data.valueVector[0], data.valueVector[1], data.valueVector[2]);
+        formatAppend(result, "%.9g, %.9g, %.9g", data.valueVector[0], data.valueVector[1], data.valueVector[2]);
         break;
     case Constant::Type_String:
     {

--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -354,22 +354,18 @@ int32_t BytecodeBuilder::addConstantNumber(double value)
     return addConstant(k, c);
 }
 
-int32_t BytecodeBuilder::addConstantVector(double x, double y, double z)
+int32_t BytecodeBuilder::addConstantVector(float x, float y, float z)
 {
-    float fx = (float)x;
-    float fy = (float)y;
-    float fz = (float)z;
-
     Constant c = {Constant::Type_Vector};
-    c.valueVector[0] = fx;
-    c.valueVector[1] = fy;
-    c.valueVector[2] = fz;
+    c.valueVector[0] = x;
+    c.valueVector[1] = y;
+    c.valueVector[2] = z;
 
     ConstantKey k = {Constant::Type_Vector};
-    static_assert(sizeof(k.value) == sizeof(fx) + sizeof(fy) && sizeof(k.extra) == sizeof(fz), "Expecting vector to have three 32-bit components");
-    memcpy(&k.value, &fx, sizeof(fx));
-    memcpy((char*)&k.value + sizeof(fx), &fy, sizeof(fy));
-    memcpy(&k.extra, &fz, sizeof(fz));
+    static_assert(sizeof(k.value) == sizeof(x) + sizeof(y) && sizeof(k.extra) == sizeof(z), "Expecting vector to have three 32-bit components");
+    memcpy(&k.value, &x, sizeof(x));
+    memcpy((char*)&k.value + sizeof(x), &y, sizeof(y));
+    memcpy(&k.extra, &z, sizeof(z));
 
     return addConstant(k, c);
 }

--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -42,6 +42,11 @@ static void writeInt(std::string& ss, int value)
     ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
 }
 
+static void writeFloat(std::string& ss, float value)
+{
+    ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
 static void writeDouble(std::string& ss, double value)
 {
     ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
@@ -147,23 +152,42 @@ size_t BytecodeBuilder::StringRefHash::operator()(const StringRef& v) const
 
 size_t BytecodeBuilder::ConstantKeyHash::operator()(const ConstantKey& key) const
 {
-    // finalizer from MurmurHash64B
-    const uint32_t m = 0x5bd1e995;
+    if (key.type == Constant::Type_Vector)
+    {
+        uint32_t i[3];
+        static_assert(sizeof(key.value) + sizeof(key.extra) == sizeof(i), "Expecting vector to have three 32-bit components");
+        memcpy(i, &key.value, sizeof(i));
 
-    uint32_t h1 = uint32_t(key.value);
-    uint32_t h2 = uint32_t(key.value >> 32) ^ (key.type * m);
+        // scramble bits to make sure that integer coordinates have entropy in lower bits
+        i[0] ^= i[0] >> 17;
+        i[1] ^= i[1] >> 17;
+        i[2] ^= i[2] >> 17;
 
-    h1 ^= h2 >> 18;
-    h1 *= m;
-    h2 ^= h1 >> 22;
-    h2 *= m;
-    h1 ^= h2 >> 17;
-    h1 *= m;
-    h2 ^= h1 >> 19;
-    h2 *= m;
+        // Optimized Spatial Hashing for Collision Detection of Deformable Objects
+        uint32_t h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
 
-    // ... truncated to 32-bit output (normally hash is equal to (uint64_t(h1) << 32) | h2, but we only really need the lower 32-bit half)
-    return size_t(h2);
+        return size_t(h);
+    }
+    else
+    {
+        // finalizer from MurmurHash64B
+        const uint32_t m = 0x5bd1e995;
+
+        uint32_t h1 = uint32_t(key.value);
+        uint32_t h2 = uint32_t(key.value >> 32) ^ (key.type * m);
+
+        h1 ^= h2 >> 18;
+        h1 *= m;
+        h2 ^= h1 >> 22;
+        h2 *= m;
+        h1 ^= h2 >> 17;
+        h1 *= m;
+        h2 ^= h1 >> 19;
+        h2 *= m;
+
+        // ... truncated to 32-bit output (normally hash is equal to (uint64_t(h1) << 32) | h2, but we only really need the lower 32-bit half)
+        return size_t(h2);
+    }
 }
 
 size_t BytecodeBuilder::TableShapeHash::operator()(const TableShape& v) const
@@ -326,6 +350,26 @@ int32_t BytecodeBuilder::addConstantNumber(double value)
     ConstantKey k = {Constant::Type_Number};
     static_assert(sizeof(k.value) == sizeof(value), "Expecting double to be 64-bit");
     memcpy(&k.value, &value, sizeof(value));
+
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addConstantVector(double x, double y, double z)
+{
+    float fx = (float)x;
+    float fy = (float)y;
+    float fz = (float)z;
+
+    Constant c = {Constant::Type_Vector};
+    c.valueVector[0] = fx;
+    c.valueVector[1] = fy;
+    c.valueVector[2] = fz;
+
+    ConstantKey k = {Constant::Type_Vector};
+    static_assert(sizeof(k.value) == sizeof(fx) + sizeof(fy) && sizeof(k.extra) == sizeof(fz), "Expecting vector to have three 32-bit components");
+    memcpy(&k.value, &fx, sizeof(fx));
+    memcpy((char*)&k.value + sizeof(fx), &fy, sizeof(fy));
+    memcpy(&k.extra, &fz, sizeof(fz));
 
     return addConstant(k, c);
 }
@@ -640,6 +684,13 @@ void BytecodeBuilder::writeFunction(std::string& ss, uint32_t id, uint8_t flags)
         case Constant::Type_Number:
             writeByte(ss, LBC_CONSTANT_NUMBER);
             writeDouble(ss, c.valueNumber);
+            break;
+
+        case Constant::Type_Vector:
+            writeByte(ss, LBC_CONSTANT_VECTOR);
+            writeFloat(ss, c.valueVector[0]);
+            writeFloat(ss, c.valueVector[1]);
+            writeFloat(ss, c.valueVector[2]);
             break;
 
         case Constant::Type_String:

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -816,6 +816,28 @@ struct Compiler
             }
         }
 
+        // Optimization: replace vector constructor calls with constant loads when all arguments are numbers
+        if (bfid == LBF_VECTOR && expr->args.size == 3 && targetCount == 1 && isConstant(expr->args.data[0]) && isConstant(expr->args.data[1]) && isConstant(expr->args.data[2]))
+        {
+            Constant cx = getConstant(expr->args.data[0]);
+            Constant cy = getConstant(expr->args.data[1]);
+            Constant cz = getConstant(expr->args.data[2]);
+
+            if (cx.type == Constant::Type_Number && cy.type == Constant::Type_Number && cz.type == Constant::Type_Number)
+            {
+                double x = cx.valueNumber;
+                double y = cy.valueNumber;
+                double z = cz.valueNumber;
+
+                int32_t cid = bytecode.addConstantVector(x, y, z);
+                if (cid < 0)
+                    CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+                emitLoadK(target, cid);
+                return;
+            }
+        }
+
         if (expr->self)
         {
             AstExprIndexName* fi = expr->func->as<AstExprIndexName>();

--- a/Compiler/src/ConstantFolding.h
+++ b/Compiler/src/ConstantFolding.h
@@ -16,6 +16,7 @@ struct Constant
         Type_Nil,
         Type_Boolean,
         Type_Number,
+        Type_Vector,
         Type_String,
     };
 
@@ -26,6 +27,7 @@ struct Constant
     {
         bool valueBoolean;
         double valueNumber;
+        float valueVector[3];
         const char* valueString = nullptr; // length stored in stringLength
     };
 

--- a/VM/src/lvmload.cpp
+++ b/VM/src/lvmload.cpp
@@ -287,6 +287,15 @@ int luau_load(lua_State* L, const char* chunkname, const char* data, size_t size
                 break;
             }
 
+            case LBC_CONSTANT_VECTOR:
+            {
+                float x = read<float>(data, size, offset);
+                float y = read<float>(data, size, offset);
+                float z = read<float>(data, size, offset);
+                setvvalue(&p->k[j], x, y, z, 0.0f);
+                break;
+            }
+
             case LBC_CONSTANT_STRING:
             {
                 TString* v = readString(strings, data, size, offset);

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -4497,13 +4497,13 @@ L0: RETURN R0 -1
 TEST_CASE("VectorLiterals")
 {
     CHECK_EQ("\n" + compileFunction("return Vector3.new(1, 2, 3)", 0, 2, true), R"(
-LOADK R0 K0 []
+LOADK R0 K0 [1, 2, 3]
 RETURN R0 1
 )");
 
     CHECK_EQ("\n" + compileFunction("print(Vector3.new(1, 2, 3))", 0, 2, true), R"(
 GETIMPORT R0 1 [print]
-LOADK R1 K2 []
+LOADK R1 K2 [1, 2, 3]
 CALL R0 1 0
 RETURN R0 0
 )");

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -17,12 +17,17 @@ std::string rep(const std::string& s, size_t n);
 
 using namespace Luau;
 
-static std::string compileFunction(const char* source, uint32_t id, int optimizationLevel = 1)
+static std::string compileFunction(const char* source, uint32_t id, int optimizationLevel = 1, bool enableVectors = false)
 {
     Luau::BytecodeBuilder bcb;
     bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code);
     Luau::CompileOptions options;
     options.optimizationLevel = optimizationLevel;
+    if (enableVectors)
+    {
+        options.vectorLib = "Vector3";
+        options.vectorCtor = "new";
+    }
     Luau::compileOrThrow(bcb, source, options);
 
     return bcb.dumpFunction(id);
@@ -4486,6 +4491,21 @@ FASTCALL 54 L0
 GETIMPORT R0 2 [Vector3.new]
 CALL R0 3 -1
 L0: RETURN R0 -1
+)");
+}
+
+TEST_CASE("VectorLiterals")
+{
+    CHECK_EQ("\n" + compileFunction("return Vector3.new(1, 2, 3)", 0, 2, true), R"(
+LOADK R0 K0 []
+RETURN R0 1
+)");
+
+    CHECK_EQ("\n" + compileFunction("print(Vector3.new(1, 2, 3))", 0, 2, true), R"(
+GETIMPORT R0 1 [print]
+LOADK R1 K2 []
+CALL R0 1 0
+RETURN R0 0
 )");
 }
 


### PR DESCRIPTION
Built-in vector constructor calls with exactly three arguments are detected by the compiler and turned into vector constants when the arguments are constant numbers. This optimization requires optimization level 2 because built-ins are not folded otherwise by the compiler. Bytecode version is bumped because of the new constant type, but old bytecode versions can still be loaded. A synthetic benchmark, which creates vectors in a loop, shows 6.6x improvement.