### PR TITLE
Add #include <algorithm> to fix building with gcc 14

### DIFF
--- a/Analysis/src/ConstraintSolver.cpp
+++ b/Analysis/src/ConstraintSolver.cpp
@@ -17,6 +17,7 @@
 #include "Luau/TypeUtils.h"
 #include "Luau/Unifier2.h"
 #include "Luau/VisitType.h"
+#include <algorithm>
 #include <utility>
 
 LUAU_FASTFLAGVARIABLE(DebugLuauLogSolver, false);

--- a/Analysis/src/Instantiation.cpp
+++ b/Analysis/src/Instantiation.cpp
@@ -7,6 +7,8 @@
 #include "Luau/TypeArena.h"
 #include "Luau/TypeCheckLimits.h"
 
+#include <algorithm>
+
 LUAU_FASTFLAG(DebugLuauDeferredConstraintResolution)
 
 namespace Luau

--- a/CodeGen/src/IrAnalysis.cpp
+++ b/CodeGen/src/IrAnalysis.cpp
@@ -8,6 +8,7 @@
 
 #include "lobject.h"
 
+#include <algorithm>
 #include <bitset>
 
 #include <stddef.h>

--- a/tests/RuntimeLimits.test.cpp
+++ b/tests/RuntimeLimits.test.cpp
@@ -13,6 +13,8 @@
 
 #include "doctest.h"
 
+#include <algorithm>
+
 using namespace Luau;
 
 struct LimitFixture : BuiltinsFixture


### PR DESCRIPTION
With gcc 14 some C++ Standard Library headers have been changed to no longer include other headers that were used internally by the library. In luau's case it is the `<algorithm>` header.

[Downstream Gentoo bug](https://bugs.gentoo.org/917017)

[GCC 14 porting guide](https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes)