### PR TITLE
Fix gcc-13 build on Linux

### DIFF
--- a/CodeGen/include/Luau/BytecodeSummary.h
+++ b/CodeGen/include/Luau/BytecodeSummary.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include <stdint.h>
+
 struct lua_State;
 struct Proto;
 
@@ -35,12 +37,12 @@ public:
         return line;
     }
 
-    const unsigned getNestingLimit() const
+    unsigned getNestingLimit() const
     {
         return nestingLimit;
     }
 
-    const unsigned getOpLimit() const
+    unsigned getOpLimit() const
     {
         return LOP__COUNT;
     }


### PR DESCRIPTION
uint8_t requires stdint.h include. Also remove redundant consts as a drive-by.