### PR TITLE
Use ubuntu-latest on GHA when possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   unix:
     strategy:
       matrix:
-        os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}]
+        os: [{name: ubuntu, version: ubuntu-latest}, {name: macos, version: macos-latest}]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
     steps:
@@ -83,7 +83,7 @@ jobs:
         Debug/luau-compile tests/conformance/assert.lua
 
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # needed for clang++-10 to avoid gcov compatibility issues
     steps:
     - uses: actions/checkout@v2
     - name: install
@@ -99,7 +99,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   web:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v2

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   build:
     needs: ["create-release"]
     strategy:
-      matrix:
+      matrix: # using ubuntu-20.04 to build a Linux binary targeting older glibc to improve compatibility
         os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
@@ -56,7 +56,7 @@ jobs:
 
   web:
     needs: ["create-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     strategy:
-      matrix:
+      matrix: # using ubuntu-20.04 to build a Linux binary targeting older glibc to improve compatibility
         os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
@@ -35,7 +35,7 @@ jobs:
         path: Release\luau*.exe
 
   web:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v2


### PR DESCRIPTION
We need ubuntu-20.04 for coverage analysis (clang after 10 doesn't seem to properly interact with gcov version used for codecov) and for releases (to produce binaries targeting earlier glibc).

However, we still should be verifying that Luau builds on latest, because newer toolchains have stricter standard library headers and/or warnings; without this we're at risk of constantly regressing the build for packaging or external applications.

Note that release.yml can probably just be deleted but for now we simply adjust it.