### PR TITLE
Only build fuzzer with CMake if 3.26 is available

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,5 +1,8 @@
 # This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
-cmake_minimum_required(VERSION 3.26)
+if(${CMAKE_VERSION} VERSION_LESS "3.26")
+    message(WARNING "Building the Luau fuzzer requires Clang version 3.26 of higher.")
+    return()
+endif()
 
 include(FetchContent)
 


### PR DESCRIPTION
`cmake_minimum_required` is a blocking check and raising required minimal CMake version only for the fuzzer is not good for the users (<3.19 was supported before, but not sure which exact one)