### PR TITLE
Fix 'require' in benchmarks to work with new relative system

### DIFF
--- a/bench/bench_support.lua
+++ b/bench/bench_support.lua
@@ -66,7 +66,7 @@ end
 -- and 'false' otherwise.
 --
 -- Example usage:
---   local bench = script and require(script.Parent.bench_support) or require("bench_support")
+--   local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 --   function testFunc()
 --      ...
 --   end

--- a/bench/gc/test_BinaryTree.lua
+++ b/bench/gc/test_BinaryTree.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_GC_Boehm_Trees.lua
+++ b/bench/gc/test_GC_Boehm_Trees.lua
@@ -1,5 +1,5 @@
 --!nonstrict
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 local stretchTreeDepth = 18 -- about 16Mb
 local longLivedTreeDepth = 16 -- about 4Mb

--- a/bench/gc/test_GC_Tree_Pruning_Eager.lua
+++ b/bench/gc/test_GC_Tree_Pruning_Eager.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local count = 1

--- a/bench/gc/test_GC_Tree_Pruning_Gen.lua
+++ b/bench/gc/test_GC_Tree_Pruning_Gen.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local count = 1

--- a/bench/gc/test_GC_Tree_Pruning_Lazy.lua
+++ b/bench/gc/test_GC_Tree_Pruning_Lazy.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local count = 1

--- a/bench/gc/test_GC_hashtable_Keyval.lua
+++ b/bench/gc/test_GC_hashtable_Keyval.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local t = {}

--- a/bench/gc/test_LB_mandel.lua
+++ b/bench/gc/test_LB_mandel.lua
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_LargeTableCtor_array.lua
+++ b/bench/gc/test_LargeTableCtor_array.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_LargeTableCtor_hash.lua
+++ b/bench/gc/test_LargeTableCtor_hash.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_Pcall_pcall_yield.lua
+++ b/bench/gc/test_Pcall_pcall_yield.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_SunSpider_3d-raytrace.lua
+++ b/bench/gc/test_SunSpider_3d-raytrace.lua
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_TableCreate_nil.lua
+++ b/bench/gc/test_TableCreate_nil.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_TableCreate_number.lua
+++ b/bench/gc/test_TableCreate_number.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_TableCreate_zerofill.lua
+++ b/bench/gc/test_TableCreate_zerofill.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_TableMarshal_select.lua
+++ b/bench/gc/test_TableMarshal_select.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_TableMarshal_table_pack.lua
+++ b/bench/gc/test_TableMarshal_table_pack.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/gc/test_TableMarshal_varargs.lua
+++ b/bench/gc/test_TableMarshal_varargs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_AbsSum_abs.lua
+++ b/bench/micro_tests/test_AbsSum_abs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_AbsSum_and_or.lua
+++ b/bench/micro_tests/test_AbsSum_and_or.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_AbsSum_math_abs.lua
+++ b/bench/micro_tests/test_AbsSum_math_abs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Assert.lua
+++ b/bench/micro_tests/test_Assert.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Factorial.lua
+++ b/bench/micro_tests/test_Factorial.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Failure_pcall_a_bar.lua
+++ b/bench/micro_tests/test_Failure_pcall_a_bar.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Failure_pcall_game_Foo.lua
+++ b/bench/micro_tests/test_Failure_pcall_game_Foo.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Failure_xpcall_a_bar.lua
+++ b/bench/micro_tests/test_Failure_xpcall_a_bar.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Failure_xpcall_game_Foo.lua
+++ b/bench/micro_tests/test_Failure_xpcall_game_Foo.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_LargeTableCtor_array.lua
+++ b/bench/micro_tests/test_LargeTableCtor_array.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_LargeTableCtor_hash.lua
+++ b/bench/micro_tests/test_LargeTableCtor_hash.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_LargeTableSum_loop_index.lua
+++ b/bench/micro_tests/test_LargeTableSum_loop_index.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_LargeTableSum_loop_ipairs.lua
+++ b/bench/micro_tests/test_LargeTableSum_loop_ipairs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_LargeTableSum_loop_iter.lua
+++ b/bench/micro_tests/test_LargeTableSum_loop_iter.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_LargeTableSum_loop_pairs.lua
+++ b/bench/micro_tests/test_LargeTableSum_loop_pairs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_MethodCalls.lua
+++ b/bench/micro_tests/test_MethodCalls.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_OOP_constructor.lua
+++ b/bench/micro_tests/test_OOP_constructor.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_OOP_method_call.lua
+++ b/bench/micro_tests/test_OOP_method_call.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_OOP_virtual_constructor.lua
+++ b/bench/micro_tests/test_OOP_virtual_constructor.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Pcall_call_return.lua
+++ b/bench/micro_tests/test_Pcall_call_return.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Pcall_pcall_return.lua
+++ b/bench/micro_tests/test_Pcall_pcall_return.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Pcall_pcall_yield.lua
+++ b/bench/micro_tests/test_Pcall_pcall_yield.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_Pcall_xpcall_return.lua
+++ b/bench/micro_tests/test_Pcall_xpcall_return.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_SqrtSum_exponent.lua
+++ b/bench/micro_tests/test_SqrtSum_exponent.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_SqrtSum_math_sqrt.lua
+++ b/bench/micro_tests/test_SqrtSum_math_sqrt.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_SqrtSum_sqrt.lua
+++ b/bench/micro_tests/test_SqrtSum_sqrt.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_SqrtSum_sqrt_getfenv.lua
+++ b/bench/micro_tests/test_SqrtSum_sqrt_getfenv.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_SqrtSum_sqrt_roundabout.lua
+++ b/bench/micro_tests/test_SqrtSum_sqrt_roundabout.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_StringInterp.lua
+++ b/bench/micro_tests/test_StringInterp.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 bench.runCode(function()
     for j=1,1e6 do

--- a/bench/micro_tests/test_TableCreate_nil.lua
+++ b/bench/micro_tests/test_TableCreate_nil.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableCreate_number.lua
+++ b/bench/micro_tests/test_TableCreate_number.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableCreate_zerofill.lua
+++ b/bench/micro_tests/test_TableCreate_zerofill.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableFind_loop_ipairs.lua
+++ b/bench/micro_tests/test_TableFind_loop_ipairs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableFind_table_find.lua
+++ b/bench/micro_tests/test_TableFind_table_find.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableInsertion_index_cached.lua
+++ b/bench/micro_tests/test_TableInsertion_index_cached.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableInsertion_index_len.lua
+++ b/bench/micro_tests/test_TableInsertion_index_len.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableInsertion_table_insert.lua
+++ b/bench/micro_tests/test_TableInsertion_table_insert.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableInsertion_table_insert_index.lua
+++ b/bench/micro_tests/test_TableInsertion_table_insert_index.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableIteration.lua
+++ b/bench/micro_tests/test_TableIteration.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableMarshal_select.lua
+++ b/bench/micro_tests/test_TableMarshal_select.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableMarshal_table_pack.lua
+++ b/bench/micro_tests/test_TableMarshal_table_pack.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableMarshal_table_unpack_array.lua
+++ b/bench/micro_tests/test_TableMarshal_table_unpack_array.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableMarshal_table_unpack_range.lua
+++ b/bench/micro_tests/test_TableMarshal_table_unpack_range.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableMarshal_varargs.lua
+++ b/bench/micro_tests/test_TableMarshal_varargs.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableMove_empty_table.lua
+++ b/bench/micro_tests/test_TableMove_empty_table.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local t = table.create(250001, 0)

--- a/bench/micro_tests/test_TableMove_same_table.lua
+++ b/bench/micro_tests/test_TableMove_same_table.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local t = table.create(5000001, 0)

--- a/bench/micro_tests/test_TableMove_table_create.lua
+++ b/bench/micro_tests/test_TableMove_table_create.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
     local t = table.create(250001, 0)

--- a/bench/micro_tests/test_TableRemoval_table_remove.lua
+++ b/bench/micro_tests/test_TableRemoval_table_remove.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_TableSort.lua
+++ b/bench/micro_tests/test_TableSort.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 local arr_months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
 

--- a/bench/micro_tests/test_ToNumberString.lua
+++ b/bench/micro_tests/test_ToNumberString.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 bench.runCode(function()
     for j=1,1e6 do

--- a/bench/micro_tests/test_UpvalueCapture.lua
+++ b/bench/micro_tests/test_UpvalueCapture.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_VariadicSelect.lua
+++ b/bench/micro_tests/test_VariadicSelect.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/micro_tests/test_string_lib.lua
+++ b/bench/micro_tests/test_string_lib.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 bench.runCode(function()
 	local src = string.rep("abcdefghijklmnopqrstuvwxyz", 100)

--- a/bench/micro_tests/test_table_concat.lua
+++ b/bench/micro_tests/test_table_concat.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 bench.runCode(function()
 	for outer=1,28,3 do

--- a/bench/tests/base64.lua
+++ b/bench/tests/base64.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/chess.lua
+++ b/bench/tests/chess.lua
@@ -1,5 +1,5 @@
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 local RANKS = "12345678"
 local FILES = "abcdefgh"

--- a/bench/tests/life.lua
+++ b/bench/tests/life.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/matrixmult.lua
+++ b/bench/tests/matrixmult.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 local function mmul(matrix1, matrix2)
     local shapeRows = #matrix1

--- a/bench/tests/mesh-normal-scalar.lua
+++ b/bench/tests/mesh-normal-scalar.lua
@@ -1,5 +1,5 @@
 --!strict
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/pcmmix.lua
+++ b/bench/tests/pcmmix.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 local samples = 100_000
 

--- a/bench/tests/qsort.lua
+++ b/bench/tests/qsort.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/sha256.lua
+++ b/bench/tests/sha256.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/ack.lua
+++ b/bench/tests/shootout/ack.lua
@@ -23,7 +23,7 @@ SOFTWARE.
 ]]
 -- http://www.bagley.org/~doug/shootout/
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/binary-trees.lua
+++ b/bench/tests/shootout/binary-trees.lua
@@ -25,7 +25,7 @@ SOFTWARE.
 -- http://benchmarksgame.alioth.debian.org/
 -- contributed by Mike Pall
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/fannkuch-redux.lua
+++ b/bench/tests/shootout/fannkuch-redux.lua
@@ -25,7 +25,7 @@ SOFTWARE.
 -- http://benchmarksgame.alioth.debian.org/
 -- contributed by Mike Pall
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/fixpoint-fact.lua
+++ b/bench/tests/shootout/fixpoint-fact.lua
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/heapsort.lua
+++ b/bench/tests/shootout/heapsort.lua
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/mandel.lua
+++ b/bench/tests/shootout/mandel.lua
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/n-body.lua
+++ b/bench/tests/shootout/n-body.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/qt.lua
+++ b/bench/tests/shootout/qt.lua
@@ -23,7 +23,7 @@ SOFTWARE.
 ]]
 -- Julia sets via interval cell-mapping (quadtree version)
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/queen.lua
+++ b/bench/tests/shootout/queen.lua
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/scimark.lua
+++ b/bench/tests/shootout/scimark.lua
@@ -33,7 +33,7 @@
 -- Modification to be compatible with Lua 5.3
 ------------------------------------------------------------------------------
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/shootout/spectral-norm.lua
+++ b/bench/tests/shootout/spectral-norm.lua
@@ -25,7 +25,7 @@ SOFTWARE.
 -- http://benchmarksgame.alioth.debian.org/
 -- contributed by Mike Pall
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sieve.lua
+++ b/bench/tests/sieve.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/3d-cube.lua
+++ b/bench/tests/sunspider/3d-cube.lua
@@ -2,7 +2,7 @@
 -- http://www.speich.net/computer/moztesting/3d.htm
 -- Created by Simon Speich
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/3d-morph.lua
+++ b/bench/tests/sunspider/3d-morph.lua
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 ]]
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/3d-raytrace.lua
+++ b/bench/tests/sunspider/3d-raytrace.lua
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/controlflow-recursive.lua
+++ b/bench/tests/sunspider/controlflow-recursive.lua
@@ -3,7 +3,7 @@
    http://shootout.alioth.debian.org/
    contributed by Isaac Gouy
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/crypto-aes.lua
+++ b/bench/tests/sunspider/crypto-aes.lua
@@ -9,7 +9,7 @@
  *   returns byte-array encrypted value (16 bytes)
  */]]
 
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 -- Sbox is pre-computed multiplicative inverse in GF(2^8) used in SubBytes and KeyExpansion [§5.1.1]
 local Sbox =  { 0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,

--- a/bench/tests/sunspider/fannkuch.lua
+++ b/bench/tests/sunspider/fannkuch.lua
@@ -3,7 +3,7 @@
    http://shootout.alioth.debian.org/
    contributed by Isaac Gouy
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/math-cordic.lua
+++ b/bench/tests/sunspider/math-cordic.lua
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  ]]
 
- local bench = script and require(script.Parent.bench_support) or require("bench_support")
+ local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/math-partial-sums.lua
+++ b/bench/tests/sunspider/math-partial-sums.lua
@@ -3,7 +3,7 @@
    http://shootout.alioth.debian.org/
    contributed by Isaac Gouy
 ]]
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 function test()
 

--- a/bench/tests/sunspider/n-body-oop.lua
+++ b/bench/tests/sunspider/n-body-oop.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../../bench_support")
 
 local PI = 3.141592653589793
 local SOLAR_MASS = 4 * PI * PI

--- a/bench/tests/tictactoe.lua
+++ b/bench/tests/tictactoe.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/trig.lua
+++ b/bench/tests/trig.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 function test()
 

--- a/bench/tests/voxelgen.lua
+++ b/bench/tests/voxelgen.lua
@@ -1,4 +1,4 @@
-local bench = script and require(script.Parent.bench_support) or require("bench_support")
+local bench = script and require(script.Parent.bench_support) or pcall(require, "bench_support") or require("../bench_support")
 
 -- Based on voxel terrain generator by Stickmasterluke
 


### PR DESCRIPTION
Old style require is now called with `pcall` to support comparing against Lua.
New style require is now a third option.