### PR TITLE
Check for APPLE before doing OSX-related arch checks

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     return()
 endif()
 
-if(NOT CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+if(APPLE AND NOT CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
     message(WARNING "Building the Luau fuzzer for ARM64 is currently unsupported.")
     return()
 endif()


### PR DESCRIPTION
Otherwise running CMake for the fuzzer returns the non-sensical:

```
CMake Warning at fuzz/CMakeLists.txt:18 (message):
  Building the Luau fuzzer for ARM64 is currently unsupported.
```

on x86_64 Linux.