### PR TITLE
Fix optimisation-related bugs with compileExprIndexExpr

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -1978,11 +1978,10 @@ struct Compiler
     {
         RegScope rs(this);
 
-        Constant cv = getConstant(expr->index);
-
-        if (cv.type == Constant::Type_Number && cv.valueNumber >= 1 && cv.valueNumber <= 256 && double(int(cv.valueNumber)) == cv.valueNumber)
+        if (AstExprConstantNumber* number = expr->index->as<AstExprConstantNumber>();
+            number && number->value >= 1 && number->value <= 256 && double(int(number->value)) == number->value)
         {
-            uint8_t i = uint8_t(int(cv.valueNumber) - 1);
+            uint8_t i = uint8_t(int(number->value) - 1);
 
             uint8_t rt = compileExprAuto(expr->expr, rs);
 
@@ -1990,9 +1989,9 @@ struct Compiler
 
             bytecode.emitABC(LOP_GETTABLEN, target, rt, i);
         }
-        else if (cv.type == Constant::Type_String)
+        else if (AstExprConstantString* string = expr->index->as<AstExprConstantString>())
         {
-            BytecodeBuilder::StringRef iname = sref(cv.getString());
+            BytecodeBuilder::StringRef iname = sref(string->value);
             int32_t cid = bytecode.addConstantString(iname);
             if (cid < 0)
                 CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");


### PR DESCRIPTION
Currently in Luau 0.607's `compileExprIndexExpr`:
```C
Constant cv = getConstant(expr->index);
```
always returns false, meaning the conditions that generate `LOP_GETTABLEN` and `LOP_GETTABLEKS` for string/number indexes are both unreachable, this has been fixed in this PR.

LOP_GETIMPORT can also now be generated for string indexes if optimisations are enabled.

# Comparisons

## Test 1 (unreachable string/number branches in `compileExprIndexExpr`)

Repro code:
```lua
local _ = foo["bar"]
```

Luau 0.607 with no optimisations
(output from [luau.lonegladiator.dev](https://luau.lonegladiator.dev), same output as luau-compile util):
![image](https://github.com/luau-lang/luau/assets/48674805/6808b5d5-f67d-47e7-961e-292a43acb100)
PR with no optimisations:
![image](https://github.com/luau-lang/luau/assets/48674805/4f8c1a39-5b51-4180-b020-7aef2c172408)

## Test 2 (LOP_GETIMPORT for `compileExprIndexExpr`)

Repro code:
```lua
local _ = foo["bar"]
```

Luau 0.607 with -O1 and -O2:
![image](https://github.com/luau-lang/luau/assets/48674805/1e1cff70-d56a-4b01-a6b1-edb9300c646c)
PR with -O1 and -O2:
![image](https://github.com/luau-lang/luau/assets/48674805/00ae8993-3b66-4b10-9647-b1c55587c585)



