### PR TITLE
Fix missing include for `std::exchange`

### DIFF
--- a/Common/include/Luau/VecDeque.h
+++ b/Common/include/Luau/VecDeque.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <new>
 #include <stdexcept>
+#include <utility>
 
 namespace Luau
 {


### PR DESCRIPTION
On GCC 12.3.0 (NixOS 23.11), I couldn't manage to compile Luau without this change. I checked [the page on cppreference.com](https://en.cppreference.com/w/cpp/utility/exchange), and it turned out that `std::exchange` is available since C++14, and it comes from `<utility>`. This one-liner fixed my build.