### PR TITLE
Fix setting sandbox on Lua instance without strlib

### DIFF
--- a/VM/src/linit.cpp
+++ b/VM/src/linit.cpp
@@ -43,9 +43,13 @@ void luaL_sandbox(lua_State* L)
 
     // set all builtin metatables to read-only
     lua_pushliteral(L, "");
-    lua_getmetatable(L, -1);
-    lua_setreadonly(L, -1, true);
-    lua_pop(L, 2);
+    if (lua_getmetatable(L, -1))
+    {
+        lua_setreadonly(L, -1, true);
+        lua_pop(L, 2);
+    }
+    else
+        lua_pop(L, 1);
 
     // set globals to readonly and activate safeenv since the env is immutable
     lua_setreadonly(L, LUA_GLOBALSINDEX, true);

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -884,6 +884,17 @@ TEST_CASE("NewUserdataOverflow")
     CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: block too big") == 0);
 }
 
+TEST_CASE("SandboxWithoutLibs")
+{
+    StateRef globalState(luaL_newstate(), lua_close);
+    lua_State* L = globalState.get();
+
+    luaopen_base(L); // Load only base library
+    luaL_sandbox(L);
+
+    CHECK(lua_getreadonly(L, LUA_GLOBALSINDEX));
+}
+
 TEST_CASE("ApiTables")
 {
     StateRef globalState(luaL_newstate(), lua_close);


### PR DESCRIPTION
Currently calling `luaL_sandbox` on Lua instance without loaded strlib causes crash (assertion).
It happens because inside `luaL_sandbox` there is no check that metatable  for strings is present.
