### PR TITLE
Enable newly added M1 GHA CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   unix:
     strategy:
       matrix:
-        os: [{name: ubuntu, version: ubuntu-latest}, {name: macos, version: macos-latest}]
+        os: [{name: ubuntu, version: ubuntu-latest}, {name: macos, version: macos-latest}, {name: macos-arm, version: macos-14}]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
     steps:


### PR DESCRIPTION
GitHub just released support for M1 runners for open source projects via GHA. It can be selected by using macos-14 OS to run on.

This is very valuable because until now, Luau wasn't tested in OSS CI on Arm64, despite the presence of a fairly large volume of AArch64 specific code courtesy of A64 codegen. This change fixes that.

In the future we could also expand codecov reporting as it seems to work well but it needs a little bit of cleanup for the build in question so let's start small.