### PR TITLE
Added install commands to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,3 +271,22 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
         endif()
     endif()
 endforeach()
+
+# define the install steps
+include(GNUInstallDirs)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/VM/include/" "${PROJECT_SOURCE_DIR}/AST/include/" "${PROJECT_SOURCE_DIR}/Compiler/include/"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.hpp"
+        PATTERN "*.inl")
+
+install(TARGETS Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.VM
+        EXPORT luau
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if (LUAU_BUILD_CLI)
+install(TARGETS Luau.Repl.CLI Luau.Analyze.CLI Luau.Compile.CLI
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()


### PR DESCRIPTION
Some package managers like vcpkg rely on CMake to install the built binaries. Adds the standard boilerplate to install headers, static libs, and binaries via the install target.