### PR TITLE
luau-compile: Fix usage of vector-ctor without vector-lib

### DIFF
--- a/CLI/Compile.cpp
+++ b/CLI/Compile.cpp
@@ -46,10 +46,9 @@ struct GlobalOptions
     int optimizationLevel = 1;
     int debugLevel = 1;
 
-    std::string vectorLib;
-    std::string vectorCtor;
-    std::string vectorType;
-
+    const char* vectorLib;
+    const char* vectorCtor;
+    const char* vectorType;
 } globalOptions;
 
 static Luau::CompileOptions copts()
@@ -58,10 +57,9 @@ static Luau::CompileOptions copts()
     result.optimizationLevel = globalOptions.optimizationLevel;
     result.debugLevel = globalOptions.debugLevel;
 
-    // globalOptions outlive the CompileOptions, so it's safe to use string data pointers here
-    result.vectorLib = globalOptions.vectorLib.empty() ? nullptr : globalOptions.vectorLib.c_str();
-    result.vectorCtor = globalOptions.vectorCtor.c_str();
-    result.vectorType = globalOptions.vectorType.c_str();
+    result.vectorLib = globalOptions.vectorLib;
+    result.vectorCtor = globalOptions.vectorCtor;
+    result.vectorType = globalOptions.vectorType;
 
     return result;
 }

--- a/CLI/Compile.cpp
+++ b/CLI/Compile.cpp
@@ -59,7 +59,7 @@ static Luau::CompileOptions copts()
     result.debugLevel = globalOptions.debugLevel;
 
     // globalOptions outlive the CompileOptions, so it's safe to use string data pointers here
-    result.vectorLib = globalOptions.vectorLib.c_str();
+    result.vectorLib = globalOptions.vectorLib.empty() ? nullptr : globalOptions.vectorLib.c_str();
     result.vectorCtor = globalOptions.vectorCtor.c_str();
     result.vectorType = globalOptions.vectorType.c_str();
 

--- a/CLI/Compile.cpp
+++ b/CLI/Compile.cpp
@@ -46,9 +46,9 @@ struct GlobalOptions
     int optimizationLevel = 1;
     int debugLevel = 1;
 
-    const char* vectorLib;
-    const char* vectorCtor;
-    const char* vectorType;
+    const char* vectorLib = nullptr;
+    const char* vectorCtor = nullptr;
+    const char* vectorType = nullptr;
 } globalOptions;
 
 static Luau::CompileOptions copts()


### PR DESCRIPTION
When --vector-lib is not specified, CompileOptions::vectorLib was set to an empty string. This resulted in the builtin matching not working, since vectorLib must either be a null pointer or a pointer to a valid global identifier.