### PR TITLE
CodeGen: Optimize vector ops for X64 when the source is computed

### DIFF
--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -624,7 +624,7 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         ScopedRegX64 tmp2{regs};
 
         RegisterX64 tmpa = vecOp(inst.a, tmp1);
-        RegisterX64 tmpb = vecOp(inst.b, tmp2);
+        RegisterX64 tmpb = (inst.a == inst.b) ? tmpa : vecOp(inst.b, tmp2);
 
         build.vsubps(inst.regX64, tmpa, tmpb);
         if (!FFlag::LuauCodegenVectorTag)
@@ -654,7 +654,7 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         ScopedRegX64 tmp2{regs};
 
         RegisterX64 tmpa = vecOp(inst.a, tmp1);
-        RegisterX64 tmpb = vecOp(inst.b, tmp2);
+        RegisterX64 tmpb = (inst.a == inst.b) ? tmpa : vecOp(inst.b, tmp2);
 
         build.vdivps(inst.regX64, tmpa, tmpb);
         if (!FFlag::LuauCodegenVectorTag)

--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -608,7 +608,7 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         ScopedRegX64 tmp2{regs};
 
         RegisterX64 tmpa = vecOp(inst.a, tmp1);
-        RegisterX64 tmpb = vecOp(inst.b, tmp2);
+        RegisterX64 tmpb = (inst.a == inst.b) ? tmpa : vecOp(inst.b, tmp2);
 
         build.vaddps(inst.regX64, tmpa, tmpb);
 
@@ -639,7 +639,7 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         ScopedRegX64 tmp2{regs};
 
         RegisterX64 tmpa = vecOp(inst.a, tmp1);
-        RegisterX64 tmpb = vecOp(inst.b, tmp2);
+        RegisterX64 tmpb = (inst.a == inst.b) ? tmpa : vecOp(inst.b, tmp2);
 
         build.vmulps(inst.regX64, tmpa, tmpb);
         if (!FFlag::LuauCodegenVectorTag)

--- a/CodeGen/src/IrLoweringX64.h
+++ b/CodeGen/src/IrLoweringX64.h
@@ -51,6 +51,7 @@ struct IrLoweringX64
     OperandX64 memRegTagOp(IrOp op);
     RegisterX64 regOp(IrOp op);
     OperandX64 bufferAddrOp(IrOp bufferOp, IrOp indexOp);
+    RegisterX64 vecOp(IrOp op, ScopedRegX64& tmp);
 
     IrConst constOp(IrOp op) const;
     uint8_t tagOp(IrOp op) const;


### PR DESCRIPTION
With the TAG_VECTOR change, we can now confidently distinguish cases when the .w component
contains TVECTOR tag from cases where it doesn't: loads and tag ops produce the tag, whereas
other instructions don't.

We now take advantage of this fact and only apply vandps with a mask when we need to.

It would be possible to use a positive filter (explicitly checking for source coming from ADD_VEC
et al), but there are more instructions to check this way and this is purely an optimization so
it is allowed to be conservative (as in, the cost of a mistake here is a potential slowdown,
not a correctness issue).

Additionally, this change only performs vandps once when the arguments are the same instead
of doing it twice.

On the function that computes a polynomial approximation this change makes it ~20% faster on Zen4.