### PR TITLE
Work around ASLR+ASAN compatibility issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ${{matrix.os.version}}
     steps:
     - uses: actions/checkout@v1
+    - name: work around ASLR+ASAN compatibility
+      run: sudo sysctl -w vm.mmap_rnd_bits=28
+      if: matrix.os.name == 'ubuntu'
     - name: make tests
       run: |
         make -j2 config=sanitize werror=1 native=1 luau-tests


### PR DESCRIPTION
vm.mmap_rnd_bits has been recently changed to 32 on GHA, which triggers issues in ASAN builds that spuriously fail on startup. The fix requires a more recent clang/gcc than the agents have available (clang 17, not sure what GCC version), so for now we need to work around this by restricting the ASLR randomness.

See https://github.com/google/sanitizers/issues/1614