### PR TITLE
Make table.concat faster

### DIFF
--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -314,7 +314,7 @@ static int tconcat(lua_State* L)
     for (; i < last; i++)
     {
         addfield(L, &b, i, t);
-        if (!DFFlag::LuauFasterConcat || lsep)
+        if (!DFFlag::LuauFasterConcat || lsep != 0)
             luaL_addlstring(&b, sep, lsep);
     }
     if (i == last) // add last value (if interval was not empty)

--- a/tests/conformance/tables.lua
+++ b/tests/conformance/tables.lua
@@ -412,6 +412,25 @@ do
   assert(table.find({[(1)] = true}, true) == 1)
 end
 
+-- test table.concat
+do
+  -- hash elements
+  local t = {}
+  t[123] = "a"
+  t[124] = "b"
+
+  assert(table.concat(t) == "")
+  assert(table.concat(t, ",", 123, 124) == "a,b")
+  assert(table.concat(t, ",", 123, 123) == "a")
+
+  -- numeric values
+  assert(table.concat({1, 2, 3}, ",") == "1,2,3")
+  assert(table.concat({"a", 2, "c"}, ",") == "a,2,c")
+
+  -- out of bounds indices => element is nil => error
+  assert(pcall(table.concat, t, ",", 1, 100) == false)
+end
+
 -- test indexing with strings that have zeroes embedded in them
 do
 	local t = {}

--- a/tests/conformance/tables.lua
+++ b/tests/conformance/tables.lua
@@ -414,6 +414,13 @@ end
 
 -- test table.concat
 do
+  -- regular usage
+  assert(table.concat({}) == "")
+  assert(table.concat({}, ",") == "")
+  assert(table.concat({"a", "b", "c"}, ",") == "a,b,c")
+  assert(table.concat({"a", "b", "c"}, ",", 2) == "b,c")
+  assert(table.concat({"a", "b", "c"}, ",", 1, 2) == "a,b")
+
   -- hash elements
   local t = {}
   t[123] = "a"
@@ -427,7 +434,9 @@ do
   assert(table.concat({1, 2, 3}, ",") == "1,2,3")
   assert(table.concat({"a", 2, "c"}, ",") == "a,2,c")
 
-  -- out of bounds indices => element is nil => error
+  -- error cases
+  assert(pcall(table.concat, "") == false)
+  assert(pcall(table.concat, t, false) == false)
   assert(pcall(table.concat, t, ",", 1, 100) == false)
 end
 


### PR DESCRIPTION
table.concat is idiomatic and should be the fastest way to concatenate all table array elements together, but apparently you can beat it by using `string.format`, `string.rep` and `table.unpack`:

```lua
string.format(string.rep("%*", #t), table.unpack(t))
```

... this just won't do, so we should fix table.concat performance.

The deficit comes from two places:

- rawgeti overhead followed by other stack accesses, all to extract a string from what is almost always an in-bounds array lookup
- addlstring overhead in case separator is empty (extra function calls)

This change fixes this by using a fast path for in-bounds array lookup for a string. Note that `table.concat` also supports numbers (these need to be converted to strings which is a little cumbersome and has innate overhead), and out-of-bounds accesses*. In these cases we fall back to the old implementation.

To trigger out-of-bounds accesses, you need to skip the past-array-end element (which is nil per array invariant), but this is achievable because table.concat supports offset+length arguments. This should almost never come up in practice but the per-element branches et al are fairly cheap compared to the eventual string copy/alloc anyway.

This change makes table.concat ~2x faster when the separator is empty; the table.concat benchmark shows +40% gains but it uses a variety of string separators of different lengths so it doesn't get the full benefit from this change.