### PR TITLE
add cmake folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build/
 /build[.-]*/
+/cmake/
+/cmake[.-]*/
 /coverage/
 /.vs/
 /.vscode/


### PR DESCRIPTION
In the readme file under the building section, it specifies that you should run the command `mkdir cmake && cd cmake`; however, the folder is not currently being ignored.