### PR TITLE
Fix confusing warning when CMake version is too low

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
 if(${CMAKE_VERSION} VERSION_LESS "3.26")
-    message(WARNING "Building the Luau fuzzer requires Clang version 3.26 of higher.")
+    message(WARNING "Building the Luau fuzzer requires CMake version 3.26 or higher.")
     return()
 endif()
 


### PR DESCRIPTION
Experienced brief moment of panic when this warning said I had clang 3 installed.