### PR TITLE
implement leading bar and ampersand in types

### DIFF
--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -17,6 +17,7 @@ LUAU_FASTINTVARIABLE(LuauParseErrorLimit, 100)
 // flag so that we don't break production games by reverting syntax changes.
 // See docs/SyntaxChanges.md for an explanation.
 LUAU_FASTFLAGVARIABLE(DebugLuauDeferredConstraintResolution, false)
+LUAU_FASTFLAGVARIABLE(LuauLeadingBarAndAmpersand, false)
 
 namespace Luau
 {
@@ -1524,7 +1525,7 @@ AstType* Parser::parseTypeSuffix(AstType* type, const Location& begin)
 {
     TempVector<AstType*> parts(scratchType);
 
-    if (type != nullptr)
+    if (!FFlag::LuauLeadingBarAndAmpersand || type != nullptr)
     {
         parts.push_back(type);
     }
@@ -1626,24 +1627,35 @@ AstTypeOrPack Parser::parseTypeOrPack()
 
 AstType* Parser::parseType(bool inDeclarationContext)
 {
-    Location begin = lexer.current().location;
-
     unsigned int oldRecursionCount = recursionCounter;
     // recursion counter is incremented in parseSimpleType and/or parseTypeSuffix
 
-    AstType* type = nullptr;
+    Location begin = lexer.current().location;
 
-    Lexeme::Type c = lexer.current().type;
-    if (c != '|' && c != '&')
+    if (FFlag::LuauLeadingBarAndAmpersand)
     {
-        type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
+        AstType* type = nullptr;
+
+        Lexeme::Type c = lexer.current().type;
+        if (c != '|' && c != '&')
+        {
+            type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
+            recursionCounter = oldRecursionCount;
+        }
+
+        AstType* typeWithSuffix = parseTypeSuffix(type, begin);
         recursionCounter = oldRecursionCount;
+
+        return typeWithSuffix;
     }
+    else
+    {
+        AstType* type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
 
-    AstType* typeWithSuffix = parseTypeSuffix(type, begin);
-    recursionCounter = oldRecursionCount;
+        recursionCounter = oldRecursionCount;
 
-    return typeWithSuffix;
+        return parseTypeSuffix(type, begin);
+    }
 }
 
 // Type ::= nil | Name[`.' Name] [ `<' Type [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}'

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1628,20 +1628,22 @@ AstType* Parser::parseType(bool inDeclarationContext)
 {
     Location begin = lexer.current().location;
 
+    unsigned int oldRecursionCount = recursionCounter;
+    // recursion counter is incremented in parseSimpleType and/or parseTypeSuffix
+
+    AstType* type = nullptr;
+
     Lexeme::Type c = lexer.current().type;
-    if (c == '|' || c == '&')
+    if (c != '|' && c != '&')
     {
-        return parseTypeSuffix(nullptr, begin);
+        type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
+        recursionCounter = oldRecursionCount;
     }
 
-    unsigned int oldRecursionCount = recursionCounter;
-    // recursion counter is incremented in parseSimpleType
-
-    AstType* type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
-
+    AstType* typeWithSuffix = parseTypeSuffix(type, begin);
     recursionCounter = oldRecursionCount;
 
-    return parseTypeSuffix(type, begin);
+    return typeWithSuffix;
 }
 
 // Type ::= nil | Name[`.' Name] [ `<' Type [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}'

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1523,7 +1523,11 @@ AstType* Parser::parseFunctionTypeTail(const Lexeme& begin, AstArray<AstGenericT
 AstType* Parser::parseTypeSuffix(AstType* type, const Location& begin)
 {
     TempVector<AstType*> parts(scratchType);
-    parts.push_back(type);
+
+    if (type != nullptr)
+    {
+        parts.push_back(type);
+    }
 
     incrementRecursionCounter("type annotation");
 
@@ -1622,10 +1626,16 @@ AstTypeOrPack Parser::parseTypeOrPack()
 
 AstType* Parser::parseType(bool inDeclarationContext)
 {
+    Location begin = lexer.current().location;
+
+    Lexeme::Type c = lexer.current().type;
+    if (c == '|' || c == '&')
+    {
+        return parseTypeSuffix(nullptr, begin);
+    }
+
     unsigned int oldRecursionCount = recursionCounter;
     // recursion counter is incremented in parseSimpleType
-
-    Location begin = lexer.current().location;
 
     AstType* type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
 

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -3187,6 +3187,7 @@ TEST_CASE_FIXTURE(Fixture, "mixed_leading_intersection_and_union_not_allowed")
     ScopedFastFlag sff{FFlag::LuauLeadingBarAndAmpersand, true};
 
     matchParseError("type A = & number | string | boolean", "Mixing union and intersection types is not allowed; consider wrapping in parentheses.");
+    matchParseError("type A = | number & string & boolean", "Mixing union and intersection types is not allowed; consider wrapping in parentheses.");
 }
 
 TEST_SUITE_END();

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -16,6 +16,7 @@ LUAU_FASTINT(LuauRecursionLimit);
 LUAU_FASTINT(LuauTypeLengthLimit);
 LUAU_FASTINT(LuauParseErrorLimit);
 LUAU_FASTFLAG(DebugLuauDeferredConstraintResolution);
+LUAU_FASTFLAG(LuauLeadingBarAndAmpersand);
 
 namespace
 {
@@ -3169,11 +3170,15 @@ TEST_CASE_FIXTURE(Fixture, "read_write_table_properties")
 
 TEST_CASE_FIXTURE(Fixture, "can_parse_leading_bar_unions_successfully")
 {
+    ScopedFastFlag sff{FFlag::LuauLeadingBarAndAmpersand, true};
+
     parse(R"(type A = | "Hello" | "World")");
 }
 
 TEST_CASE_FIXTURE(Fixture, "can_parse_leading_ampersand_intersections_successfully")
 {
+    ScopedFastFlag sff{FFlag::LuauLeadingBarAndAmpersand, true};
+
     parse(R"(type A = & { string } & { number })");
 }
 

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -3182,4 +3182,11 @@ TEST_CASE_FIXTURE(Fixture, "can_parse_leading_ampersand_intersections_successful
     parse(R"(type A = & { string } & { number })");
 }
 
+TEST_CASE_FIXTURE(Fixture, "mixed_leading_intersection_and_union_not_allowed")
+{
+    ScopedFastFlag sff{FFlag::LuauLeadingBarAndAmpersand, true};
+
+    matchParseError("type A = & number | string | boolean", "Mixing union and intersection types is not allowed; consider wrapping in parentheses.");
+}
+
 TEST_SUITE_END();

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -3167,4 +3167,14 @@ TEST_CASE_FIXTURE(Fixture, "read_write_table_properties")
     LUAU_ASSERT(pr.errors.size() == 0);
 }
 
+TEST_CASE_FIXTURE(Fixture, "can_parse_leading_bar_unions_successfully")
+{
+    parse(R"(type A = | "Hello" | "World")");
+}
+
+TEST_CASE_FIXTURE(Fixture, "can_parse_leading_ampersand_intersections_successfully")
+{
+    parse(R"(type A = & { string } & { number })");
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Implements the [Leading `|` and `&` in types](https://rfcs.luau-lang.org/syntax-leading-bar-and-ampersand.html) RFC.

The changes to the parser are exactly as described in the RFC.
I added two tests, one for leading `|` and one for leading `&`.