### PR TITLE
Fix incorrect comment in Bytecode.h

### DIFF
--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -360,8 +360,8 @@ enum LuauOpcode
 
     // SUBRK, DIVRK: compute arithmetic operation between the constant and a source register and put the result into target register
     // A: target register
-    // B: source register
-    // C: constant table index (0..255); must refer to a number
+    // B: constant table index (0..255); must refer to a number
+    // C: source register
     LOP_SUBRK,
     LOP_DIVRK,
 


### PR DESCRIPTION
The description of SUBRK/DIVRK is out of sync with the VM code.

Comment:
```cpp
// SUBRK, DIVRK: compute arithmetic operation between the constant and a source register and put the result into target register
// A: target register
// B: source register
// C: constant table index (0..255); must refer to a number
LOP_SUBRK,
LOP_DIVRK,
```
VM snippet:
```cpp
VM_CASE(LOP_DIVRK)
    {
        Instruction insn = *pc++;
        StkId ra = VM_REG(LUAU_INSN_A(insn));
        TValue* kv = VM_KV(LUAU_INSN_B(insn));
        StkId rc = VM_REG(LUAU_INSN_C(insn));
        ...
```