### PR TITLE
disallow variadic type packs in parenthesized types when in return position

### DIFF
--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -22,6 +22,7 @@ LUAU_FASTFLAGVARIABLE(LuauLeadingBarAndAmpersand2, false)
 LUAU_FASTFLAGVARIABLE(LuauNativeAttribute, false)
 LUAU_FASTFLAGVARIABLE(LuauAttributeSyntaxFunExpr, false)
 LUAU_FASTFLAGVARIABLE(LuauDeclarationExtraPropData, false)
+LUAU_FASTFLAGVARIABLE(LuauDisallowVariadicInReturnParenType, false)
 
 namespace Luau
 {
@@ -1463,7 +1464,7 @@ std::pair<Location, AstTypeList> Parser::parseReturnType()
     if (lexer.current().type != Lexeme::SkinnyArrow && resultNames.empty())
     {
         // If it turns out that it's just '(A)', it's possible that there are unions/intersections to follow, so fold over it.
-        if (result.size() == 1 && !varargAnnotation)
+        if (result.size() == 1 && (!FFlag::LuauDisallowVariadicInReturnParenType || !varargAnnotation))
         {
             AstType* returnType = parseTypeSuffix(result[0], innerBegin);
 

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1463,7 +1463,7 @@ std::pair<Location, AstTypeList> Parser::parseReturnType()
     if (lexer.current().type != Lexeme::SkinnyArrow && resultNames.empty())
     {
         // If it turns out that it's just '(A)', it's possible that there are unions/intersections to follow, so fold over it.
-        if (result.size() == 1)
+        if (result.size() == 1 && !varargAnnotation)
         {
             AstType* returnType = parseTypeSuffix(result[0], innerBegin);
 

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -20,6 +20,7 @@ LUAU_FASTFLAG(LuauAttributeSyntax);
 LUAU_FASTFLAG(LuauLeadingBarAndAmpersand2);
 LUAU_FASTFLAG(LuauAttributeSyntaxFunExpr);
 LUAU_FASTFLAG(LuauDeclarationExtraPropData);
+LUAU_FASTFLAG(LuauDisallowVariadicInReturnParenType);
 
 namespace
 {
@@ -3565,5 +3566,11 @@ TEST_CASE_FIXTURE(Fixture, "mixed_leading_intersection_and_union_not_allowed")
     matchParseError("type A = | number & string & boolean", "Mixing union and intersection types is not allowed; consider wrapping in parentheses.");
 }
 
+TEXT_CASE_FIXTURE(Fixture, "do_not_parse_variadic_type_in_paren_type_in_returns")
+{
+    ScopedFastFlag sff{FFlag::LuauDisallowVariadicInReturnParenType, true};
+
+    matchParseError("local function f(): (number, ...string) | boolean end", "Expected identifier when parsing expression, got '|'");
+}
 
 TEST_SUITE_END();

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -3566,7 +3566,7 @@ TEST_CASE_FIXTURE(Fixture, "mixed_leading_intersection_and_union_not_allowed")
     matchParseError("type A = | number & string & boolean", "Mixing union and intersection types is not allowed; consider wrapping in parentheses.");
 }
 
-TEXT_CASE_FIXTURE(Fixture, "do_not_parse_variadic_type_in_paren_type_in_returns")
+TEST_CASE_FIXTURE(Fixture, "do_not_parse_variadic_type_in_paren_type_in_returns")
 {
     ScopedFastFlag sff{FFlag::LuauDisallowVariadicInReturnParenType, true};
 


### PR DESCRIPTION
This PR *is* a breaking change, but I doubt anyone uses the syntax.
```lua
local function a(): (string, ...number) | boolean -- valid syntax, but weird type
local function a(): (string, buffer, ...number) | boolean -- syntax error
local function a(): (...number) | boolean -- syntax error
```
This PR makes the first example a syntax error, which it should be.