### PR TITLE
BytecodeBuilder.cpp: fix invalid assumption that int32_t aliases int

### DIFF
--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -1836,7 +1836,7 @@ void BytecodeBuilder::dumpConstant(std::string& result, int k) const
     }
     case Constant::Type_Import:
     {
-        int id0 = -1, id1 = -1, id2 = -1;
+        int32_t id0 = -1, id1 = -1, id2 = -1;
         if (int count = decomposeImportId(data.valueImport, id0, id1, id2))
         {
             {


### PR DESCRIPTION
I found that Luau failed to build on the devkitPro toolchain for 3DS.

This target uses an ILP32 model, and `int32_t` is an alias of `long`. `BytecodeBuilder.cpp` includes a line where an `int` is passed by reference to a function expecting an `int32_t`.

This PR fixes that line. It'd be nice to get the fix upstream. Thanks for your consideration!

As a sidenote, I also found an issue in the toolchain affecting `Parser.cpp`, where `limits.h` did not include `ULLONG_MAX`. That's probably a toolchain issue, but including `climits` rather than `limits.h` fixes it. It's possible that the C++ standard and C standard were out of sync in the toolchain, because `limits.h` defines `ULLONG_MAX` for C99 and above. `climits` is guaranteed to define it for C++11 and above. If you're open to switching the include to `climits`, that'd be convenient for us, but this is a small patch and not a big deal for us to maintain downstream.