### PR TITLE
"CollapseClauseToAssert" lint/suggestion

### DIFF
--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -2657,9 +2657,7 @@ private:
             // Don't give the suggestion in this case, we don't want to slow people's code down.
             if (!errmsg->is<AstExprConstantString>())
                 return true;
-
-            AstExprConstantString* string = errmsg->as<AstExprConstantString>();
-
+            
             emitWarning(
                 *context,
                 LintWarning::Code_CollapseClauseToAssert,

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -2587,6 +2587,91 @@ private:
     }
 };
 
+// Recommend collapsing `if/if not COND then error(STR) end` to `assert(COND, STR)`
+class LintCollapseClauseToAssert : AstVisitor
+{
+public:
+    LUAU_NOINLINE static void process(LintContext& context)
+    {
+        LintCollapseClauseToAssert pass{&context};
+        context.root->visit(&pass);
+    }
+
+private:
+    LintContext* context;
+
+    LintCollapseClauseToAssert(LintContext* context)
+        : context(context)
+    {
+    }
+
+    bool visit(AstStatIf* stat) override
+    {
+        if (stat->elsebody)
+            return true;
+
+        if (!stat->thenbody)
+            return true;
+
+        // Clause contains more than just an `error()`
+        if (stat->thenbody->body.size > 1)
+            return true;
+
+        Luau::AstArray<Luau::AstStat*>& contents = stat->thenbody->body;
+
+        // Avoid nullptr-dereference if there's a syntax error
+        if (contents.size < 1)
+            return true;
+
+        Luau::AstStat* body = contents.data[0];
+
+        if (!body->is<AstStatExpr>())
+            return true;
+
+        AstStatExpr* expr = body->as<AstStatExpr>();
+        
+        if (!expr->expr->is<AstExprCall>())
+            return true;
+
+        AstExprCall* call = expr->expr->as<AstExprCall>();
+
+        if (!call->func->is<AstExprGlobal>())
+            return true;
+
+        AstExprGlobal* global = call->func->as<AstExprGlobal>();
+
+        if (global->name == "error")
+        {
+            // `assert` does not have a 'level' parameter +
+            // `error` requires at-least 1 argument
+            if (call->args.size > 1 || call->args.size == 0)
+                return true;
+
+            AstExpr* errmsg = call->args.data[0];
+
+            // The `if`-clause allows the VM to occasionally (and, in this case, almost always) 
+            // avoid resolving any string operations, but `assert` (like all functions)
+            // forces it to resolve it's arguments every time they are called, regardless
+            // of if the condition actually fails.
+            // https://devforum.roblox.com/t/1289175
+            // Don't give the suggestion in this case, we don't want to slow people's code down.
+            if (!errmsg->is<AstExprConstantString>())
+                return true;
+
+            AstExprConstantString* string = errmsg->as<AstExprConstantString>();
+
+            emitWarning(
+                *context,
+                LintWarning::Code_CollapseClauseToAssert,
+                stat->location,
+                "`if`-clause can be collapsed to an `assert`"
+            );
+        }
+
+        return true;
+    }
+};
+
 class LintDuplicateCondition : AstVisitor
 {
 public:
@@ -3388,6 +3473,9 @@ std::vector<LintWarning> lint(
 
     if (context.warningEnabled(LintWarning::Code_ComparisonPrecedence))
         LintComparisonPrecedence::process(context);
+
+    if (context.warningEnabled(LintWarning::Code_CollapseClauseToAssert))
+        LintCollapseClauseToAssert::process(context);
 
     if (FFlag::LuauNativeAttribute && FFlag::LintRedundantNativeAttribute && context.warningEnabled(LintWarning::Code_RedundantNativeAttribute))
     {

--- a/Config/include/Luau/LinterConfig.h
+++ b/Config/include/Luau/LinterConfig.h
@@ -50,6 +50,7 @@ struct LintWarning
         Code_IntegerParsing = 27,
         Code_ComparisonPrecedence = 28,
         Code_RedundantNativeAttribute = 29,
+        Code_CollapseClauseToAssert = 30,
 
         Code__Count
     };
@@ -117,6 +118,7 @@ static const char* kWarningNames[] = {
     "IntegerParsing",
     "ComparisonPrecedence",
     "RedundantNativeAttribute",
+    "CollapseClauseToAssert"
 };
 // clang-format on
 


### PR DESCRIPTION
Inspired by the following code on `luau-lang.org`:
https://luau-lang.org/2023/03/31/luau-recap-march-2023.html#:~:text=if%20not%20x%20then%20error(%27first%20argument%20is%20nil%27)%20end
 [master](https://github.com/PhoenixWhitefire/luau)

Adds the `CollapseClauseToAssert` lint, which triggers in the following code:

```luau
-- `if`-clause can be collapsed to an `assert`
if X then
    error("SomeErrorMessage")
end
```

* Any number of conditions for the `if`
* No `else` block
* `error` cannot be given a `level` argument (change in behavior as `assert` does not have a `level` parameter)
* Error string must be constant (no string interpolation/concatenation) to avoid slowdowns:
```C++
AstExpr* errmsg = call->args.data[0];

// The `if`-clause allows the VM to occasionally (and, in this case, almost always) 
// avoid resolving any string operations, but `assert` (like all functions)
// forces it to resolve it's arguments every time they are called, regardless
// of if the condition actually fails.
// https://devforum.roblox.com/t/1289175
// Don't give the suggestion in this case, we don't want to slow people's code down.
if (!errmsg->is<AstExprConstantString>())
    return true;
```
* Body must _only_ be an `error` call

For some reason, the string formatting wasn't working. I would have liked to have the message substitute the condition and error strings into the lint warning, but it's not too important.

Passed all tests w/ 0 errors, 0 skips (assuming I ran the tests correctly...)

Am I doing this right?