### PR TITLE
Make `os.clock` use `clock_gettime` on FreeBSD

### DIFF
--- a/Ast/src/TimeTrace.cpp
+++ b/Ast/src/TimeTrace.cpp
@@ -40,7 +40,7 @@ static double getClockPeriod()
     mach_timebase_info_data_t result = {};
     mach_timebase_info(&result);
     return double(result.numer) / double(result.denom) * 1e-9;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     return 1e-9;
 #else
     return 1.0 / double(CLOCKS_PER_SEC);
@@ -55,7 +55,7 @@ static double getClockTimestamp()
     return double(result.QuadPart);
 #elif defined(__APPLE__)
     return double(mach_absolute_time());
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     return now.tv_sec * 1e9 + now.tv_nsec;

--- a/VM/src/lperf.cpp
+++ b/VM/src/lperf.cpp
@@ -30,7 +30,7 @@ static double clock_period()
     mach_timebase_info_data_t result = {};
     mach_timebase_info(&result);
     return double(result.numer) / double(result.denom) * 1e-9;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     return 1e-9;
 #else
     return 1.0 / double(CLOCKS_PER_SEC);

--- a/VM/src/lperf.cpp
+++ b/VM/src/lperf.cpp
@@ -45,7 +45,7 @@ static double clock_timestamp()
     return double(result.QuadPart);
 #elif defined(__APPLE__)
     return double(mach_absolute_time());
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     return now.tv_sec * 1e9 + now.tv_nsec;


### PR DESCRIPTION
I think [`clock()`](https://man.freebsd.org/cgi/man.cgi?clock) is processor time used by the program on FreeBSD (that's what it is [in Linux](https://www.man7.org/linux/man-pages/man3/clock.3.html)). On Linux, Apple, and Windows, `os.clock()` [isn't specific](https://github.com/luau-lang/luau/blob/bfad1fa7771c97e29648dd98fe94953660b02f80/VM/src/lperf.cpp#L40) to the program.

Would `CLOCK_MONOTONIC_RAW` be better or worse here, since it doesn't slew time for adjustments like NTP? `QueryPerformanceCounter` on Windows isn't slewed for NTP, I don't know if `mach_absolute_time` is. It's only supported since Linux 2.6.28 though.