### PR TITLE
Enhance the CMake file for building with Android NDK r27.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(LUAU_STATIC_CRT "Link with the static CRT (/MT)" OFF)
 option(LUAU_EXTERN_C "Use extern C for all APIs" OFF)
 
 cmake_policy(SET CMP0054 NEW)
+cmake_policy(SET CMP0057 NEW)
 cmake_policy(SET CMP0091 NEW)
 
 if(LUAU_STATIC_CRT)


### PR DESCRIPTION
Without setting this new policy when building with Android NDK r27, the following error will occur. This patch fixes the issue.

```
-- Android: Selected unified Clang toolchain
-- The CXX compiler identification is Clang 18.0.1
-- The C compiler identification is Clang 18.0.1
-- Configuring incomplete, errors occurred!
 older versions.


CMake Warning (dev) at D:/a/xmake-repo/xmake-repo/ndk/android-ndk-r27/build/cmake/flags.cmake:46 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang.cmake:23 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang-CXX.cmake:1 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/CMakeCXXInformation.cmake:48 (include)
  CMakeLists.txt:24 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at D:/a/xmake-repo/xmake-repo/ndk/android-ndk-r27/build/cmake/flags.cmake:46 (if):
  if given arguments:

    "hwaddress" "IN_LIST" "ANDROID_SANITIZE"

  Unknown arguments specified
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang.cmake:23 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang-CXX.cmake:1 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/CMakeCXXInformation.cmake:48 (include)
  CMakeLists.txt:24 (project)
```