### PR TITLE
Fix possibility to trigger assert when looping through Intersection Types

### DIFF
--- a/Analysis/src/Autocomplete.cpp
+++ b/Analysis/src/Autocomplete.cpp
@@ -199,6 +199,8 @@ static TypeCorrectKind checkTypeCorrectKind(
     {
         for (TypeId id : itv->parts)
         {
+            id = follow(id);
+
             if (const FunctionType* ftv = get<FunctionType>(id); ftv && checkFunctionType(ftv))
             {
                 return TypeCorrectKind::CorrectFunctionResult;


### PR DESCRIPTION
https://github.com/luau-lang/luau/issues/1391

I don't know but adding ``id = follow(id)`` fixed the issue and when I compared the entryMap size with and without the intersection, the output was the same.

Though now regarding the Unit Test from that issue post, it's a modified version for the unit test for this one https://github.com/luau-lang/luau/pull/1392