### PR TITLE
Add default "out" folder for CMake Project Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /build[.-]*/
+/out
 /cmake/
 /cmake[.-]*/
 /coverage/


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170#ide-integration

Apparently ``/out`` is a default folder when opening the project as a CMake project in Visual Studio.

&nbsp;

Could it be added to the ``.gitignore`` please.

![image](https://github.com/user-attachments/assets/10add17c-bbfc-4811-8c43-0ed2e84c5b9e)
