### PR TITLE
Fix crash with the index type function, where it would stack overflow due to not waiting for a pending-expansion

### DIFF
--- a/Analysis/src/TypeFunction.cpp
+++ b/Analysis/src/TypeFunction.cpp
@@ -2207,13 +2207,6 @@ TypeFunctionReductionResult<TypeId> indexFunctionImpl(
 
     TypeId indexerTy = follow(typeParams.at(1));
 
-    // Whether the type is still pending.
-    // 
-    // TODO: A generalized sanity check function for all type functions?
-    // But it should be optional for customization
-    // for functions that specifically need type function
-    // This here fixes a stack overflow.
-    // https://github.com/luau-lang/luau/issues/1406
     if (isPending(indexerTy, ctx->solver))
     {
         return {std::nullopt, false, {indexerTy}, {}};

--- a/Analysis/src/TypeFunction.cpp
+++ b/Analysis/src/TypeFunction.cpp
@@ -2206,6 +2206,19 @@ TypeFunctionReductionResult<TypeId> indexFunctionImpl(
         return {std::nullopt, true, {}, {}};
 
     TypeId indexerTy = follow(typeParams.at(1));
+
+    // Whether the type is still pending.
+    // 
+    // TODO: A generalized sanity check function for all type functions?
+    // But it should be optional for customization
+    // for functions that specifically need type function
+    // This here fixes a stack overflow.
+    // https://github.com/luau-lang/luau/issues/1406
+    if (isPending(indexerTy, ctx->solver))
+    {
+        return {std::nullopt, false, {indexerTy}, {}};
+    }
+
     std::shared_ptr<const NormalizedType> indexerNormTy = ctx->normalizer->normalize(indexerTy);
 
     // if the indexer failed to normalize, we can't reduce, but know nothing about inhabitance.

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -927,6 +927,32 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "index_type_function_works")
     CHECK_EQ("string", toString(tpm->givenTp));
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_wait_for_pending_no_crash")
+{
+    if (!FFlag::LuauSolverV2)
+        return;
+
+    CheckResult result = check(R"(
+        local PlayerData = {
+            Coins = 0,
+            Level = 1,
+            Exp = 0,
+            MaxExp = 100
+        }
+
+        type Keys = index<typeof(PlayerData), keyof<typeof(PlayerData)>>
+
+        -- This function makes it think that there's going to be a pending expansion
+        local function UpdateData(key: Keys, value)
+            PlayerData[key] = value
+        end
+
+        UpdateData("Coins", 2)
+    )");
+
+    // Should not crash!
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "index_type_function_works_w_array")
 {
     if (!FFlag::LuauSolverV2)


### PR DESCRIPTION
Fix for https://github.com/luau-lang/luau/issues/1406

While it is good to let ``index`` wait for the pending-expansion. To re-produce the issue you need more than just this code: https://i.imgur.com/b3OmUGF.png

It needs this, else it won't crash.

```lua
local function ProblemCauser(key: Keys, value)
    PlayerData[key] = value
end
```

&nbsp;

But regarding "pending things", I'd recommend **generalized functions** for sanity checks like these, since there will be more cases of similar issues I believe. But I am 100% sure that eventually this issue here can maybe be prevented if looking at the Constraints. _(And optimization)_ Not sure if ``index`` needs the table fully completed, or if it is preferred that the info is available based on **how much info is available at the current position in the code**.

But if this gets done, I hope that they'll be connected to the Solver Logger, because I actually refined mine with colors and more info _(yet need to finish that)_ to understand the Luau Source Code more and to debug issues.