### PR TITLE
HUGE fix for Type Functions, which also fixes an issue reported in the devforums and should make solving faster

### DIFF
--- a/Analysis/include/Luau/ConstraintSolver.h
+++ b/Analysis/include/Luau/ConstraintSolver.h
@@ -98,6 +98,13 @@ struct ConstraintSolver
     DenseHashSet<TypeId> generalizedTypes_{nullptr};
     const NotNull<DenseHashSet<TypeId>> generalizedTypes{&generalizedTypes_};
 
+    // The current Constraint that is being processed, can be nullptr.
+    const Constraint* currentConstraintRef;
+
+    // Offset of current pushed constraints
+    // Used to ensure things are pushes in an order within a vector.
+    int curUnsolvedConstraintPushOffset;
+
     // Recorded errors that take place within the solver.
     ErrorVec errors;
 
@@ -295,6 +302,21 @@ public:
      * @param cv the body of the constraint.
      **/
     NotNull<Constraint> pushConstraint(NotNull<Scope> scope, const Location& location, ConstraintV cv);
+
+    /** Push a Constraint right at the position after a specific constraint.
+     * @param cv the body of the constraint.
+     * @param afterConstraint The constraint to find in unsolvedConstraints to insert the new constraint after at.
+     * @param b_isFromRecursive
+        Whether this function is being called from the current dispatch through a recursive context
+        to apply insert offset.
+     **/
+    NotNull<Constraint> pushConstraintAfter(
+        NotNull<Scope> scope,
+        const Location& location,
+        ConstraintV cv,
+        const Constraint& afterConstraint,
+        bool b_isFromRecursive = false
+    );
 
     /**
      * Attempts to resolve a module from its module information. Returns the

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -953,6 +953,36 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "index_wait_for_pending_no_crash")
     // Should not crash!
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "keyof_andGeneralTypeFunction_dependency_issue1")
+{
+    if (!FFlag::LuauSolverV2)
+        return;
+
+    // Explanation https://devforum.roblox.com/t/new-type-solver-beta/3155804/97
+
+    CheckResult result = check(R"(
+        --!strict
+
+        local PlayerData = {
+            Coins = 0,
+            Level = 1,
+            Exp = 0,
+            MaxExp = 100
+        }
+
+        type Keys = keyof<typeof(PlayerData)>
+
+        -- This function makes it think that there's going to be a pending expansion
+        local function UpdateData(key: Keys, value)
+            PlayerData[key] = value
+        end
+
+        UpdateData("Coins", 2)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "index_type_function_works_w_array")
 {
     if (!FFlag::LuauSolverV2)


### PR DESCRIPTION
@alexmccord :) I did it!

I fixed the ``tabletype`` thing even though **when I found this fix that I am submitting here** I wasn't pursuing to fix that, but I had the feeling that this would resolve a bunch of stuff.


Infact this fixes and should also this [Devforum Post](https://devforum.roblox.com/t/new-type-solver-beta/3155804/97) _(if you check the message it replies to)_ which I added the **Unit Test** for this fix as well.

It doesn't break any **Unit Tests**.


# So why is this change HUGE?

![image](https://github.com/user-attachments/assets/09f221db-5327-45f8-aefd-0a10426fef28)

This comment says:
> Adding ReduceConstraint on type function for the constraint solver

But did you actually know that it pushes the new constraints **AT THE END**?

**It causes the following issue:**

<details>
<summary>Explanation with Pseudocode example</summary>

```lua
-- This is just a demonstration to explain, not a functional thing to test
type TestTable = {
 A: number, B: number, C: number
}


-- Hello, I am the Solver!
-- I solve Constraints


-- Hello again, I am the Solver!
-- I notice that there's something here...
type Test = keyof<TestTable>

-- Me the Solver, has processed it. It's a Type Function!
-- We need to reduce this type function.
-- I am going to PUSH new Constraints
-- I will push them to the very end!


local test: Test -- Assuming that this is a dependency, it gets blocked and skipped and not resolved right after keyof :(


-- Hello again, I am the Solver!
-- I have reached the end, but I am not finished yet.
-- Oh! The ReduceConstraint is here, lemme process it
-- Okay, lemme go back to the top!

-- Only then, all the dependencies are resolved...
```

And yes, you can move ``keyof`` at the bottom to prevent that from happening.

But this doesn't make sense.
</details>

&nbsp;



&nbsp;

### Type Functions can produce a ReduceConstraint
But the Solver pushes them at the end, and if your type function is closer to the end, it will solve it immediately. This doesn't make sense.

Considering that this however is true, **it is a fact**. And this fact makes it very reasonable for this fix to be correct and the actual intended way on how Type Functions should be resolved.

&nbsp;

## What did I change?

I changed a concept.

I can change the implementation on request. I can also FFlag it.

![image](https://github.com/user-attachments/assets/e252fb7b-cbc9-4e4c-af1e-b6e2a6adc69f)


**But the point is that I am pushing the new created constraints right after the Type Function Constraint.** This also prevents things from getting blocked, **hence why solving should be faster**.


&nbsp;

Here are changes that you can use in https://luau-lang.github.io/dcr-timetraveler/:

**WITHOUT THE FIX:** https://paste.ivr.fi/raw/oqukuqobyt

**WITH THE FIX:** https://paste.ivr.fi/raw/itopunanyz

&nbsp;

<details>
<summary>Differences</summary>

### Before
![image](https://github.com/user-attachments/assets/87a1c67f-beaf-4476-b458-5b322b47af99)


### After
![image](https://github.com/user-attachments/assets/04c68a8b-2e2a-4ad3-b8f5-8743bd529d56)


</details>

&nbsp;

@alexmccord Initially the thought was that ``keyof`` doesn't wait for ``typetable`` and figuring out the fix for it would be very a bit difficult for me.

But by making myself more debug logging I learned A LOT about the ConstraintSolver. Learning that it creates Constraints at the wrong position.

![image](https://github.com/user-attachments/assets/fecb6144-fb92-4c05-98ae-b01a4c1f69a6)


&nbsp;

We can think of Type Functions not being standalone Constraints. They're like more than one, however because of the current issue it's being delayed which is bad and causes issues, a lot of issues.

If one plans to implement User Defined Type Functions, I am pretty sure that this fix can help reduce headaches and other problems.

&nbsp;

The Solver works Up to Down and with this fix, it supports that more.

My change makes these Constraints happen at the time they were actually meant to happen.

<img src="https://github.com/user-attachments/assets/d8963978-645b-4cae-865f-975839d2cf00" height="320px"></img>
