### PR TITLE
PrimitiveTypeConstraint force dispatch fix

### DIFF
--- a/Analysis/include/Luau/ConstraintSolver.h
+++ b/Analysis/include/Luau/ConstraintSolver.h
@@ -172,7 +172,7 @@ public:
     bool tryDispatch(const TypeAliasExpansionConstraint& c, NotNull<const Constraint> constraint);
     bool tryDispatch(const FunctionCallConstraint& c, NotNull<const Constraint> constraint);
     bool tryDispatch(const FunctionCheckConstraint& c, NotNull<const Constraint> constraint);
-    bool tryDispatch(const PrimitiveTypeConstraint& c, NotNull<const Constraint> constraint);
+    bool tryDispatch(const PrimitiveTypeConstraint& c, NotNull<const Constraint> constraint, bool force);
     bool tryDispatch(const HasPropConstraint& c, NotNull<const Constraint> constraint);
 
 

--- a/tests/TypeInfer.primitives.test.cpp
+++ b/tests/TypeInfer.primitives.test.cpp
@@ -96,6 +96,24 @@ TEST_CASE_FIXTURE(Fixture, "check_methods_of_number")
     }
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "primitive_types_issue_IfThenElseIf_union_simplification")
+{
+    if (!FFlag::LuauSolverV2)
+        return;
+
+    CheckResult result = check(R"(
+local v1: string?
+
+local stringButItIsHere = "Windows"
+
+v1 = if true then stringButItIsHere
+elseif false then "Something"
+else "Other"
+)");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_CASE("singleton_types")
 {
     BuiltinsFixture a;


### PR DESCRIPTION
Fix for https://github.com/luau-lang/luau/issues/1395

```cpp
TEST_CASE_FIXTURE(BuiltinsFixture, "primitive_types_issue_IfThenElseIf_union_simplification")
{
    if (!FFlag::LuauSolverV2)
        return;

    CheckResult result = check(R"(
local v1: string?

local stringButItIsHere = "Windows"

v1 = if true then stringButItIsHere
elseif false then "Something"
else "Other"
)");

    LUAU_REQUIRE_NO_ERRORS(result);
}
```

This fixes this from erroring.


I've mentioned issue before. Also in this Discord Thread https://discord.com/channels/385151591524597761/1283231116387680388

e.g. @alexmccord @andyfriesen 

I also mentioned it to @aatxe regarding one earlier fix breaking 

Now, while this maybe doesn't go in-depth about the issue and uses **``force``**.

I do remember the mention that Force Dispatches were once meant to be taken away. But the thing is they're still there and they have a function and I think this is a great fix **as a fallback** in the meantime.

This fix doesn't break any other Unit Test.

&nbp;

**PrimitiveTypeConstraints** are able to block themselves with the type they own. There's just one issue. IF there's ever a case like this one, where there are _"cyclic TypeId dependency type things"_ it will fail and cause an issue.

&nbsp;

The actual optimized fix might be somewhere else and the simplification the ConstraintGenerator wants to do for ``if then else elseif``