### PR TITLE
TyperChecker2 fix which ended up as UnionType Table Indexer Support

### DIFF
--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -690,6 +690,85 @@ TEST_CASE_FIXTURE(ClassFixture, "vector2_multiply_is_overloaded")
     CHECK("mul<Vector2, string>" == toString(requireType("v4")));
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "union_used_as_table_indexer_assignProp_no_error")
+{
+    if (!FFlag::LuauSolverV2)
+        return;
+
+    CheckResult check1 = check(R"(
+--!strict
+
+type NumberTable = {
+    One: number,
+    Two: number,
+    Three: number
+}
+
+type Indexables = "One" | "Two" | "Three" | typeof(5)
+
+type Test = {
+    TestKey: number,
+    [Indexables | "Four"]: number
+}
+
+local tbl = {} :: Test 
+
+-- This was just used to compare it with index
+-- type TestIndex = index<typeof(tbl), "Three">
+
+tbl["Three"] = 3;
+tbl.Three = 3;
+tbl.Four = 4;
+tbl.TestKey = 5;
+)");
+
+    // It should be possible to do "tbl.Three" without erroring.
+    LUAU_REQUIRE_NO_ERRORS(check1);
+
+    // auto test1 = requireTypeAlias("TestIndex");
+    // auto test2 = requireType("tbl");
+
+    // TODO: This doesn't include the autocomplete fix
+    // That has to be still made.
+    // It is supposed to include the indexes from the UnionType
+    // but it is possible to have more than just that
+    // It's also to note that strings may not be the only indexable things
+    // auto ac = autocomplete('1');
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "keyof_used_as_table_indexer_assignProp_no_error")
+{
+    if (!FFlag::LuauSolverV2)
+        return;
+
+    CheckResult check1 = check(R"(
+--!strict
+
+type NumberTable = {
+    One: number,
+    Two: number,
+    Three: number
+}
+
+type Indexables = keyof<NumberTable>
+
+type Test = {
+    TestKey: number,
+    [Indexables | "Four"]: number
+}
+
+local tbl = {} :: Test 
+
+tbl["Three"] = 3;
+tbl.Three = 3;
+tbl.Four = 4;
+tbl.TestKey = 5;
+)");
+
+    // It should be possible to do "tbl.Three" without erroring.
+    LUAU_REQUIRE_NO_ERRORS(check1);
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "keyof_rfc_example")
 {
     if (!FFlag::LuauSolverV2)


### PR DESCRIPTION
This was supposed to fix an issue mentioned in the Discord Server. https://discord.com/channels/385151591524597761/906369439262461992/1284683079587336212

It starts with TypeChecker2, however the cause of it is because of two things and I believe that the fix in TypeChecker2 isn't ideal, or maybe is even skipping the cache?

The first one is TypeChecker2. And the second one is because UnionType doesn't "reduce" as ``props``. e.g. some sort of simplify. We'd need an RFC that defines what Syntax UnionType should have when making tables, that is not ``[indexer]`` as **you can only have one**.

I am not sure what **``seen``** is for, but I think it's to reduce things getting recomputed or something, not sure.

&nbsp;

```lua
type unionType = "A" | "B" | "C"
type Test = {
  [unionType]: number;
}
```
Make it loop through all the unions when index into Test through Assign Prop? _(But I want to change it to use the Subtyping functionality instead since it has a cache)_

Or to add them into the ``props`` of the **``TableType``** upon **``NameConstraint``** dispatch or something.
```
type Test = {
  A: number, B: number, C: number
}
```

This is what I was thinking about. And currently it loops. 🤷 
But it's only if you use a UnionType as an indexer.

This also means that **keyof** works!

&nbsp;

The thing is Luau only wants one table indexer. What's funny is that we can sorta have multiple purely with Union Types!

Performance can be questioned though.

``index<>`` doesn't have any issue and can index without any problems. But TypeChecker2 didn't know about the functions and I didn't want to include any Headers because I am unsure if anyone would of want more Header Files being included at certain places.

&nbsp;

I do feel like that there's been maybe two or more functions doing the same thing instead of SOLID Principle.