### PR TITLE
bit32.tohex

### DIFF
--- a/CodeGen/src/BytecodeAnalysis.cpp
+++ b/CodeGen/src/BytecodeAnalysis.cpp
@@ -444,6 +444,11 @@ static void applyBuiltinCall(int bfid, BytecodeTypes& types)
         types.result = LBC_TYPE_NUMBER;
         types.a = LBC_TYPE_NUMBER;
         break;
+    case LBF_BIT32_TOHEX:
+        types.result = LBC_TYPE_STRING;
+        types.a = LBC_TYPE_NUMBER;
+        types.b = LBC_TYPE_NUMBER;
+        break;
     case LBF_BUFFER_READI8:
     case LBF_BUFFER_READU8:
         types.result = LBC_TYPE_NUMBER;

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -523,6 +523,7 @@ static void handleBuiltinEffects(ConstPropState& state, LuauBuiltinFunction bfid
     case LBF_TONUMBER:
     case LBF_TOSTRING:
     case LBF_BIT32_BYTESWAP:
+    case LBF_BIT32_TOHEX:
     case LBF_BUFFER_READI8:
     case LBF_BUFFER_READU8:
     case LBF_BUFFER_WRITEU8:

--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -586,6 +586,9 @@ enum LuauBuiltinFunction
     // bit32.byteswap(n)
     LBF_BIT32_BYTESWAP,
 
+    // bit32.tohex(n, n)
+    LBF_BIT32_TOHEX,
+
     // buffer.
     LBF_BUFFER_READI8,
     LBF_BUFFER_READU8,

--- a/Compiler/src/Builtins.cpp
+++ b/Compiler/src/Builtins.cpp
@@ -168,6 +168,8 @@ static int getBuiltinFunctionId(const Builtin& builtin, const CompileOptions& op
             return LBF_BIT32_COUNTRZ;
         if (builtin.method == "byteswap")
             return LBF_BIT32_BYTESWAP;
+        if (builtin.method == "tohex")
+            return LBF_BIT32_TOHEX;
     }
 
     if (builtin.object == "string")
@@ -445,6 +447,7 @@ BuiltinInfo getBuiltinInfo(int bfid)
         return {1, 1};
 
     case LBF_BIT32_BYTESWAP:
+    case LBF_BIT32_TOHEX:
         return {1, 1, BuiltinInfo::Flag_NoneSafe};
 
     case LBF_BUFFER_READI8:

--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -681,6 +681,7 @@ struct TypeMapVisitor : AstVisitor
             case LBF_TYPE:
             case LBF_STRING_CHAR:
             case LBF_TYPEOF:
+            case LBF_BIT32_TOHEX:
             case LBF_STRING_SUB:
             case LBF_TOSTRING:
                 recordResolvedType(node, &builtinTypes.stringType);

--- a/VM/src/lbitlib.cpp
+++ b/VM/src/lbitlib.cpp
@@ -15,6 +15,7 @@
 #define mask(n) (~((ALLONES << 1) << ((n)-1)))
 
 typedef unsigned b_uint;
+typedef signed b_int;
 
 static b_uint andaux(lua_State* L)
 {
@@ -219,6 +220,31 @@ static int b_swap(lua_State* L)
     return 1;
 }
 
+static int b_tohex(lua_State* L)
+{
+    const unsigned digitsBoundary = 8;
+
+    b_uint b = luaL_checkunsigned(L, 1);
+    b_int n = lua_isnone(L, 2) ? digitsBoundary : (b_int)luaL_checkinteger(L, 2);
+    const char* hexdigits = "0123456789abcdef";
+    char buf[digitsBoundary];
+    int i;
+    if (n < 0)
+    {
+        n = -n;
+        hexdigits = "0123456789ABCDEF";
+    }
+    if (n > digitsBoundary)
+        n = digitsBoundary;
+    for (i = (int)n; --i >= 0;)
+    {
+        buf[i] = hexdigits[b & 15];
+        b >>= 4;
+    }
+    lua_pushlstring(L, buf, (size_t)n);
+    return 1;
+}
+
 static const luaL_Reg bitlib[] = {
     {"arshift", b_arshift},
     {"band", b_and},
@@ -235,6 +261,7 @@ static const luaL_Reg bitlib[] = {
     {"countlz", b_countlz},
     {"countrz", b_countrz},
     {"byteswap", b_swap},
+    {"tohex", b_tohex},
     {NULL, NULL},
 };
 


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/da64f40d-b51a-4a00-a872-5509af7709ab" height="120px"/>

&nbsp;

I wanted to see how custom functions can be added and chose to try it with ``tohex`` that is from BitOp.


No clue if it's something special. It's from https://bitop.luajit.org/api.html

It's a sort of normalizing function.

> Returns the hexadecimal representation of the number with the specified digits.

```
print(bit.tohex(1))              --> 00000001
print(bit.tohex(-1))             --> ffffffff
print(bit.tohex(0xffffffff))     --> ffffffff
print(bit.tohex(-1, -8))         --> FFFFFFFF
print(bit.tohex(0x21, 4))        --> 0021
print(bit.tohex(0x87654321, 4))  --> 4321
```

&nbsp;

You can actually use ``string.format("%X", 15)`` to get ``F`` already, which makes ``bit32.tohex`` actually pointless, unless it's faster.

Or ``string.format("%04X", 255)`` to enforce a ``0000`` format.