### PR TITLE
Pre-populate/duplicate check class definitions (new solver)

### DIFF
--- a/tests/TypeInfer.definitions.test.cpp
+++ b/tests/TypeInfer.definitions.test.cpp
@@ -9,6 +9,8 @@
 
 using namespace Luau;
 
+LUAU_FASTFLAG(LuauNewSolverPrePopulateClasses)
+
 TEST_SUITE_BEGIN("DefinitionTests");
 
 TEST_CASE_FIXTURE(Fixture, "definition_file_simple")
@@ -492,6 +494,7 @@ TEST_CASE_FIXTURE(Fixture, "class_definition_indexer")
 
 TEST_CASE_FIXTURE(Fixture, "class_definitions_reference_other_classes")
 {
+    ScopedFastFlag _{FFlag::LuauNewSolverPrePopulateClasses, true};
     loadDefinition(R"(
         declare class Channel
             Messages: { Message }


### PR DESCRIPTION
Closes #1492
Tested and working with the test case in the aforementioned issue, along with the full defs of luau-lsp with no issues or type errors

In normal Luau files, you can use type aliases and type functions before they are declared. The same extends to declaration files, **except** in the new solver. The old solver perfectly allows this, and in fact intentionally adds it: https://github.com/luau-lang/luau/blob/db809395bf5739c895a24dc73960b9e9ab6468c5/Analysis/src/TypeInfer.cpp#L1711-L1717

This causes *much* headache and pain for external projects that make use of declaration files; namely, luau-lsp generates them from MaximumADHD's API dump, which is not ordered by dependency. This means silent error-types popping up everywhere because types are used before they are declared. The workaround would be to make code to manually reorder class definitions based on their dependencies with a bunch of code, but this is clearly not ideal, and won't work for classes dependent on each other/recursive.

The solution used here is the same as is used for type aliases - the name binding for the class is given a blocked type before running the rest of constraint generation on the block. Questions remain:
- Should the logic be split off of `checkAliases`?
- Should a bound type be used, or should the (blocked) binding type be directly emplaced with the class type? What are the ramifications of emplacing with the bound versus the raw type? One ramification was initially ran into through an assertion because the class `superTy`/`parent` was bound, and several pieces of code assume it is not, so it had to be made followed.
- Is folllowing `superTy` to set `parent` the correct workaround for the assertions thrown, or should the code expecting `parent` to be a ClassType without following it be modified instead to follow `parent`?
- Should `scope->privateTypeBindings` also be checked for the duplicate error? I would presume so, since having a class with the same name as a private alias or type function should error as well?

The extraneous whitespace changes are clang-format ones done automatically that should've been done in the last release - I can remove them if necessary and let another sync or OSS cleanup commit fix it.