### PR TITLE
Set the defining module even when the new solver cloned the type.

### DIFF
--- a/Analysis/src/ConstraintSolver.cpp
+++ b/Analysis/src/ConstraintSolver.cpp
@@ -1109,7 +1109,8 @@ bool ConstraintSolver::tryDispatch(const TypeAliasExpansionConstraint& c, NotNul
 
             target = follow(instantiated);
         }
-        else if (FFlag::LuauNewSolverPopulateTableLocations)
+
+        if (FFlag::LuauNewSolverPopulateTableLocations)
         {
             // This is a new type - redefine the location.
             ttv->definitionLocation = constraint->location;


### PR DESCRIPTION
Follow up to #1495: a small fixup for the defining module and location to get set even when cloning was required.