### PR TITLE
Fix mesh-normal-vector benchmark array access

### DIFF
--- a/bench/tests/mesh-normal-vector.lua
+++ b/bench/tests/mesh-normal-vector.lua
@@ -86,7 +86,8 @@ function test()
     function compute_triangle_cones()
         local mesh_area = 0
         
-        local i = 1
+        local pos = 1
+
         for i = 1,#mesh.indices,3 do
             local p0 = mesh.vertices[mesh.indices[i]]
             local p1 = mesh.vertices[mesh.indices[i + 1]]
@@ -100,9 +101,9 @@ function test()
             local area = vector.magnitude(normal)
             local invarea = (area == 0) and 0 or 1 / area;
             
-            mesh.triangle_cone_p[i] = (p0.p + p1.p + p2.p) / 3
-            mesh.triangle_cone_n[i] = normal * invarea
-            i += 1
+            mesh.triangle_cone_p[pos] = (p0.p + p1.p + p2.p) / 3
+            mesh.triangle_cone_n[pos] = normal * invarea
+            pos += 1
     
             mesh_area += area
         end


### PR DESCRIPTION
mesh-normal-scalar correctly fills sequential values in the output for triangle cone function, but mesh-normal-vector accidentally reuses the loop index, which results in writes to every third index of the array (1, 4, etc.).

This is both slower (as the table turns into a hash map), and incorrect, especially as we have a scalar version of the benchmark that does the right thing.

Note: there's a bunch of inefficiencies in the benchmark code that I have not fixed (around field access mostly, e.g. writing to `v.n` and then immediately reading it again). These are not ideal for performance, but they can be valuable to keep as is because this redundancy is common in real-world code, and it would be nice to see codegen optimizations eliminating most of that overhead. This one, however, is a straight up bug, and sparse arrays should not really be the thing this benchmark hits.