### PR TITLE
Remove noexcepts from Config

### DIFF
--- a/Config/include/Luau/Config.h
+++ b/Config/include/Luau/Config.h
@@ -21,10 +21,10 @@ constexpr const char* kConfigName = ".luaurc";
 struct Config
 {
     Config();
-    Config(const Config& other) noexcept;
-    Config& operator=(const Config& other) noexcept;
-    Config(Config&& other) noexcept = default;
-    Config& operator=(Config&& other) noexcept = default;
+    Config(const Config& other);
+    Config& operator=(const Config& other);
+    Config(Config&& other) = default;
+    Config& operator=(Config&& other) = default;
 
     Mode mode = Mode::Nonstrict;
 

--- a/Config/src/Config.cpp
+++ b/Config/src/Config.cpp
@@ -17,7 +17,7 @@ Config::Config()
     enabledLint.setDefaults();
 }
 
-Config::Config(const Config& other) noexcept
+Config::Config(const Config& other)
     : mode(other.mode)
     , parseOptions(other.parseOptions)
     , enabledLint(other.enabledLint)
@@ -40,7 +40,7 @@ Config::Config(const Config& other) noexcept
     }
 }
 
-Config& Config::operator=(const Config& other) noexcept
+Config& Config::operator=(const Config& other)
 {
     if (this != &other)
     {


### PR DESCRIPTION
Fixes https://github.com/luau-lang/luau/issues/1515.

By removing these `noexcept`s, we guarantee that the internal call to `std::swap` uses move semantics when a `Config` is copy-assigned.