### PR TITLE
Fix benchmark runner bug introduced in release 0.652

### DIFF
--- a/CLI/Repl.cpp
+++ b/CLI/Repl.cpp
@@ -712,7 +712,7 @@ static bool runFile(const char* name, lua_State* GL, bool repl)
     // new thread needs to have the globals sandboxed
     luaL_sandboxthread(L);
 
-    std::string chunkname = "=" + std::string(name);
+    std::string chunkname = "@" + std::string(name);
 
     std::string bytecode = Luau::compile(*source, copts());
     int status = 0;


### PR DESCRIPTION
### Problem

In release 0.652, `RequireResolver` was refactored to add support for `luau-analyze`.

As part of this update, `RuntimeRequireContext` introduced a new convention where a file's chunkname must be prefixed with `@` (e.g., `@./some/path.luau`). This change applies to all chunknames generated within `RuntimeRequireContext`. However, when a `.luau` file is executed directly from the command line (e.g., `luau ./my/script.luau`), the chunkname is still generated with the old `=` prefix (e.g., `=./some/path.luau`).

Since `RuntimeRequireContext` no longer recognizes chunknames prefixed with `=`, any attempt to directly execute a `.luau` file from the command line fails. For example, running `luau ./my/script.luau` results in an error stating that the context is unsupported. [This issue also affects tools like the benchmark runner](https://github.com/luau-lang/luau/pull/1525#issuecomment-2480454018), which rely on direct file execution.

### Solution

Update `runFile` to replace the `=` prefix in generated chunknames with `@`.