### PR TITLE
Update vector-math benchmark name to correctly display

### DIFF
--- a/bench/tests/vector-math.lua
+++ b/bench/tests/vector-math.lua
@@ -36,4 +36,4 @@ function test()
     end
 end
 
-bench.runCode(test, "vector math")
+bench.runCode(test, "vector-math")


### PR DESCRIPTION
While we could update the `awk` regular expression, we can just make the test name compatible.