### PR TITLE
CMake Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,17 @@ endif()
 
 project(Luau LANGUAGES CXX C)
 
+find_package(Git QUIET)
+if(GIT_FOUND)
+    # Get the version from the latest git tag
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+        OUTPUT_VARIABLE GIT_VERSION
+       ERROR_QUIET
+    )
+    set(PROJECT_VERSION "${GIT_VERSION}")
+endif()
+
 if (LUAU_BUILD_SHARED)
     add_library(Luau.Common SHARED)
     add_library(Luau.CLI.lib SHARED)
@@ -71,37 +82,87 @@ if(LUAU_BUILD_CLI)
     set_target_properties(Luau.Reduce.CLI PROPERTIES OUTPUT_NAME luau-reduce)
     set_target_properties(Luau.Compile.CLI PROPERTIES OUTPUT_NAME luau-compile)
     set_target_properties(Luau.Bytecode.CLI PROPERTIES OUTPUT_NAME luau-bytecode)
+
+    install(TARGETS Luau.Repl.CLI)
+    install(TARGETS Luau.Analyze.CLI)
+    install(TARGETS Luau.Ast.CLI)
+    install(TARGETS Luau.Reduce.CLI)
+    install(TARGETS Luau.Compile.CLI)
+    install(TARGETS Luau.Bytecode.CLI)
 endif()
 
 if(LUAU_BUILD_TESTS)
     add_executable(Luau.UnitTest)
     add_executable(Luau.Conformance)
     add_executable(Luau.CLI.Test)
+
+    # The unit tests aren't `install`ed
 endif()
 
 if(LUAU_BUILD_WEB)
     add_executable(Luau.Web)
+
+    # The web module isn't `install`ed - emscripten builds usually have custom
+    # packaging steps
 endif()
 
 # Proxy target to make it possible to depend on private VM headers
 add_library(Luau.VM.Internals INTERFACE)
 
+include(GNUInstallDirs)
 include(Sources.cmake)
 
+target_compile_features(Luau.Bytecode PUBLIC cxx_std_17)
+target_include_directories(Luau.Bytecode PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Bytecode/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(Luau.Bytecode PUBLIC Luau.Common)
+install(TARGETS Luau.Bytecode EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Bytecode/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
 target_compile_features(Luau.Common PUBLIC cxx_std_17)
-target_include_directories(Luau.Common PUBLIC Common/include)
+target_include_directories(Luau.Common PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common/include>
+    $<INSTALL_INTERFACE:include>
+)
+install(TARGETS Luau.Common EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Common/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.CLI.lib PUBLIC cxx_std_17)
-target_include_directories(Luau.CLI.lib PUBLIC CLI/include)
 target_link_libraries(Luau.CLI.lib PRIVATE Luau.Common Luau.Config)
+install(TARGETS Luau.CLI.lib EXPORT LuauTargets)
+target_include_directories(Luau.CLI.lib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CLI/include>
+    $<INSTALL_INTERFACE:include>
+)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/CLI/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.Ast PUBLIC cxx_std_17)
 target_include_directories(Luau.Ast PUBLIC Ast/include)
 target_link_libraries(Luau.Ast PUBLIC Luau.Common)
 
-target_compile_features(Luau.Bytecode PUBLIC cxx_std_17)
-target_include_directories(Luau.Bytecode PUBLIC Bytecode/include)
-target_link_libraries(Luau.Bytecode PUBLIC Luau.Common)
+
+target_compile_features(Luau.Ast PUBLIC cxx_std_17)
+target_include_directories(Luau.Ast PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Ast/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(Luau.Ast PUBLIC Luau.Common)
+install(TARGETS Luau.Ast EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Ast/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.Inliner PUBLIC cxx_std_17)
 target_include_directories(Luau.Inliner PUBLIC Inliner/include)
@@ -110,35 +171,87 @@ target_link_libraries(Luau.Inliner PRIVATE Luau.VM Luau.VM.Internals)
 target_link_libraries(Luau.Inliner PUBLIC Luau.Bytecode)
 
 target_compile_features(Luau.Compiler PUBLIC cxx_std_17)
-target_include_directories(Luau.Compiler PUBLIC Compiler/include)
+target_include_directories(Luau.Compiler PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Compiler/include>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(Luau.Compiler PUBLIC Luau.Ast Luau.Bytecode)
+install(TARGETS Luau.Compiler EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Compiler/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.Config PUBLIC cxx_std_17)
-target_include_directories(Luau.Config PUBLIC Config/include)
-target_link_libraries(Luau.Config PUBLIC Luau.Ast)
+target_include_directories(Luau.Config PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Config/include>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(Luau.Config PRIVATE Luau.Compiler Luau.VM)
+target_link_libraries(Luau.Config PUBLIC Luau.Ast)
+install(TARGETS Luau.Config EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Config/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.Analysis PUBLIC cxx_std_17)
-target_include_directories(Luau.Analysis PUBLIC Analysis/include)
+target_include_directories(Luau.Analysis PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Analysis/include>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(Luau.Analysis PUBLIC Luau.Ast Luau.Config)
 target_link_libraries(Luau.Analysis PRIVATE Luau.Compiler Luau.VM)
+install(TARGETS Luau.Analysis EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Analysis/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.CodeGen PRIVATE cxx_std_17)
-target_include_directories(Luau.CodeGen PUBLIC CodeGen/include)
+target_include_directories(Luau.CodeGen PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CodeGen/include>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code generation needs VM internals
 target_link_libraries(Luau.CodeGen PUBLIC Luau.Common)
+install(TARGETS Luau.CodeGen EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/CodeGen/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.VM PRIVATE cxx_std_11)
-target_include_directories(Luau.VM PUBLIC VM/include)
+target_include_directories(Luau.VM PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/VM/include>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(Luau.VM PUBLIC Luau.Common)
+install(TARGETS Luau.VM EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/VM/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_compile_features(Luau.Require PUBLIC cxx_std_17)
-target_include_directories(Luau.Require PUBLIC Require/include)
+target_include_directories(Luau.Require PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Require/include>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(Luau.Require PUBLIC Luau.Config Luau.VM)
+install(TARGETS Luau.Require EXPORT LuauTargets)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Require/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
 
 target_include_directories(isocline PUBLIC extern/isocline/include)
 
-target_include_directories(Luau.VM.Internals INTERFACE VM/src)
+target_include_directories(Luau.VM.Internals INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/VM/src>
+    # no INSTALL_INTERFACE: the `Internals` target really only exists at compile-time
+)
+install(TARGETS Luau.VM.Internals EXPORT LuauTargets)
 
 set(LUAU_OPTIONS)
 
@@ -146,6 +259,7 @@ if(MSVC)
     list(APPEND LUAU_OPTIONS /D_CRT_SECURE_NO_WARNINGS) # We need to use the portable CRT functions.
     list(APPEND LUAU_OPTIONS "/we4018") # Signed/unsigned mismatch
     list(APPEND LUAU_OPTIONS "/we4388") # Also signed/unsigned mismatch
+    list(APPEND LUAU_OPTIONS "/utf-8")
 else()
     list(APPEND LUAU_OPTIONS -Wall) # All warnings
     list(APPEND LUAU_OPTIONS -Wimplicit-fallthrough)
@@ -350,3 +464,14 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
         endif()
     endif()
 endforeach()
+
+# Installation target
+cmake_path(APPEND libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+cmake_path(APPEND includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/luau.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/luau.pc"
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/luau.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/tools/luau.pc.in
+++ b/tools/luau.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
+
+Name: Luau
+Description: A fast, small, safe, gradually typed embeddable scripting language derived from Lua
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lLuau.Require -lLuau.Bytecode -lLuau.Ast -lLuau.Compiler -lLuau.Common -lLuau.Config -lLuau.Analysis -lLuau.CodeGen -lLuau.VM


### PR DESCRIPTION
I added a cmake install target that installs the libraries, headers and the CLI binaries to CMAKE_INSTALL_PREFIX. 

This is how I built and installed luau with this PR (on a linux machine):
```
cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja -DCMAKE_INSTALL_PREFIX=$PWD/build/install
cmake --build build
cmake --install build
```

Differences from #926 and #1317:
I added a step in the CMakeLists.txt to install a pkgconfig file so that this can be used in other build systems (e.g. Meson). I can also add the cmake-only LuauConfig file back in, however this is still useable from other cmake projects [using pkgconfig](https://cmake.org/cmake/help/latest/module/FindPkgConfig.html).

The version is also detected from the latest git tag. Not sure if this is right way to automate it but it should allow installing the pkgconfig file with the correct version after a tag is created.

The minimum cmake requirement had to be bumped to 3.20, see https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files