### PR TITLE
Tokenize whitespace

### DIFF
--- a/Ast/include/Luau/Lexer.h
+++ b/Ast/include/Luau/Lexer.h
@@ -157,6 +157,7 @@ public:
     Lexer(const char* buffer, std::size_t bufferSize, AstNameTable& names, Position startPosition = {0, 0});
 
     void setSkipComments(bool skip);
+    void setSkipWhitespace(bool skip);
     void setReadNames(bool read);
 
     const Location& previousLocation() const
@@ -165,7 +166,7 @@ public:
     }
 
     const Lexeme& next();
-    const Lexeme& next(bool skipComments, bool updatePrevLocation);
+    const Lexeme& next(bool skipComments, bool skipWhitespace, bool updatePrevLocation);
     void nextline();
 
     Lexeme lookahead();
@@ -229,6 +230,7 @@ private:
     AstNameTable& names;
 
     bool skipComments;
+    bool skipWhitespace;
     bool readNames;
 
     enum class BraceType

--- a/Ast/include/Luau/Lexer.h
+++ b/Ast/include/Luau/Lexer.h
@@ -156,7 +156,7 @@ class Lexer
 public:
     Lexer(const char* buffer, std::size_t bufferSize, AstNameTable& names, Position startPosition = {0, 0});
 
-    void setSkipTrivia(bool skip);
+    void setSkipComments(bool skip);
     void setReadNames(bool read);
 
     const Location& previousLocation() const
@@ -165,7 +165,7 @@ public:
     }
 
     const Lexeme& next();
-    const Lexeme& next(bool skipTrivia, bool updatePrevLocation);
+    const Lexeme& next(bool skipComments, bool updatePrevLocation);
     void nextline();
 
     Lexeme lookahead();
@@ -228,7 +228,7 @@ private:
 
     AstNameTable& names;
 
-    bool skipTrivia;
+    bool skipComments;
     bool readNames;
 
     enum class BraceType

--- a/Ast/include/Luau/Lexer.h
+++ b/Ast/include/Luau/Lexer.h
@@ -53,6 +53,7 @@ struct Lexeme
 
         Comment,
         BlockComment,
+        Whitespace,
 
         Attribute,
 
@@ -100,7 +101,7 @@ private:
 public:
     union
     {
-        const char* data;       // String, Number, Comment
+        const char* data;       // String, Number, Comment, Whitespace
         const char* name;       // Name
         unsigned int codepoint; // BrokenUnicode
     };
@@ -155,7 +156,7 @@ class Lexer
 public:
     Lexer(const char* buffer, std::size_t bufferSize, AstNameTable& names, Position startPosition = {0, 0});
 
-    void setSkipComments(bool skip);
+    void setSkipTrivia(bool skip);
     void setReadNames(bool read);
 
     const Location& previousLocation() const
@@ -164,7 +165,7 @@ public:
     }
 
     const Lexeme& next();
-    const Lexeme& next(bool skipComments, bool updatePrevLocation);
+    const Lexeme& next(bool skipTrivia, bool updatePrevLocation);
     void nextline();
 
     Lexeme lookahead();
@@ -227,7 +228,7 @@ private:
 
     AstNameTable& names;
 
-    bool skipComments;
+    bool skipTrivia;
     bool readNames;
 
     enum class BraceType

--- a/Ast/src/Lexer.cpp
+++ b/Ast/src/Lexer.cpp
@@ -316,14 +316,14 @@ Lexer::Lexer(const char* buffer, size_t bufferSize, AstNameTable& names, Positio
           Lexeme::Eof
       )
     , names(names)
-    , skipTrivia(false)
+    , skipComments(false)
     , readNames(true)
 {
 }
 
-void Lexer::setSkipTrivia(bool skip)
+void Lexer::setSkipComments(bool skip)
 {
-    skipTrivia = skip;
+    skipComments = skip;
 }
 
 void Lexer::setReadNames(bool read)
@@ -333,12 +333,12 @@ void Lexer::setReadNames(bool read)
 
 const Lexeme& Lexer::next()
 {
-    return next(this->skipTrivia, true);
+    return next(this->skipComments, true);
 }
 
-const Lexeme& Lexer::next(bool skipTrivia, bool updatePrevLocation)
+const Lexeme& Lexer::next(bool skipComments, bool updatePrevLocation)
 {
-    // in skipTrivia mode we reject valid comments
+    // in skipComments mode we reject valid comments
     do
     {
         if (!FFlag::LuauLexerTokenizesWhitespace)
@@ -353,7 +353,7 @@ const Lexeme& Lexer::next(bool skipTrivia, bool updatePrevLocation)
 
         lexeme = readNext();
         updatePrevLocation = false;
-    } while (skipTrivia && (lexeme.type == Lexeme::Comment || lexeme.type == Lexeme::BlockComment || lexeme.type == Lexeme::Whitespace));
+    } while (skipComments && (lexeme.type == Lexeme::Comment || lexeme.type == Lexeme::BlockComment || lexeme.type == Lexeme::Whitespace));
 
     return lexeme;
 }

--- a/Ast/src/Lexer.cpp
+++ b/Ast/src/Lexer.cpp
@@ -317,6 +317,7 @@ Lexer::Lexer(const char* buffer, size_t bufferSize, AstNameTable& names, Positio
       )
     , names(names)
     , skipComments(false)
+    , skipWhitespace(true)
     , readNames(true)
 {
 }
@@ -326,6 +327,11 @@ void Lexer::setSkipComments(bool skip)
     skipComments = skip;
 }
 
+void Lexer::setSkipWhitespace(bool skip)
+{
+    skipWhitespace = skip;
+}
+
 void Lexer::setReadNames(bool read)
 {
     readNames = read;
@@ -333,10 +339,10 @@ void Lexer::setReadNames(bool read)
 
 const Lexeme& Lexer::next()
 {
-    return next(this->skipComments, true);
+    return next(this->skipComments, this->skipWhitespace, true);
 }
 
-const Lexeme& Lexer::next(bool skipComments, bool updatePrevLocation)
+const Lexeme& Lexer::next(bool skipComments, bool skipWhitespace, bool updatePrevLocation)
 {
     // in skipComments mode we reject valid comments
     do
@@ -353,7 +359,7 @@ const Lexeme& Lexer::next(bool skipComments, bool updatePrevLocation)
 
         lexeme = readNext();
         updatePrevLocation = false;
-    } while (skipComments && (lexeme.type == Lexeme::Comment || lexeme.type == Lexeme::BlockComment || lexeme.type == Lexeme::Whitespace));
+    } while ((skipComments && (lexeme.type == Lexeme::Comment || lexeme.type == Lexeme::BlockComment)) || (skipWhitespace && lexeme.type == Lexeme::Whitespace));
 
     return lexeme;
 }

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -208,7 +208,7 @@ Parser::Parser(const char* buffer, size_t bufferSize, AstNameTable& names, Alloc
     matchRecoveryStopOnToken[Lexeme::Type::Eof] = 1;
 
     // required for lookahead() to work across a comment boundary and for nextLexeme() to work when captureComments is false
-    lexer.setSkipComments(true);
+    lexer.setSkipTrivia(true);
 
     // read first lexeme (any hot comments get .header = true)
     LUAU_ASSERT(hotcommentHeader);
@@ -3572,13 +3572,13 @@ AstTypeError* Parser::reportMissingTypeError(const Location& parseErrorLocation,
 
 void Parser::nextLexeme()
 {
-    Lexeme::Type type = lexer.next(/* skipComments= */ false, true).type;
+    Lexeme::Type type = lexer.next(/* skipTrivia= */ false, true).type;
 
-    while (type == Lexeme::BrokenComment || type == Lexeme::Comment || type == Lexeme::BlockComment)
+    while (type == Lexeme::BrokenComment || type == Lexeme::Comment || type == Lexeme::BlockComment || type == Lexeme::Whitespace)
     {
         const Lexeme& lexeme = lexer.current();
 
-        if (options.captureComments)
+        if (options.captureComments && type != Lexeme::Whitespace)
             commentLocations.push_back(Comment{lexeme.type, lexeme.location});
 
         // Subtlety: Broken comments are weird because we record them as comments AND pass them to the parser as a lexeme.
@@ -3598,7 +3598,7 @@ void Parser::nextLexeme()
             hotcomments.push_back({hotcommentHeader, lexeme.location, std::string(text + 1, text + end)});
         }
 
-        type = lexer.next(/* skipComments= */ false, /* updatePrevLocation= */ false).type;
+        type = lexer.next(/* skipTrivia= */ false, /* updatePrevLocation= */ false).type;
     }
 }
 

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -208,7 +208,7 @@ Parser::Parser(const char* buffer, size_t bufferSize, AstNameTable& names, Alloc
     matchRecoveryStopOnToken[Lexeme::Type::Eof] = 1;
 
     // required for lookahead() to work across a comment boundary and for nextLexeme() to work when captureComments is false
-    lexer.setSkipTrivia(true);
+    lexer.setSkipComments(true);
 
     // read first lexeme (any hot comments get .header = true)
     LUAU_ASSERT(hotcommentHeader);
@@ -3572,7 +3572,7 @@ AstTypeError* Parser::reportMissingTypeError(const Location& parseErrorLocation,
 
 void Parser::nextLexeme()
 {
-    Lexeme::Type type = lexer.next(/* skipTrivia= */ false, true).type;
+    Lexeme::Type type = lexer.next(/* skipComments= */ false, true).type;
 
     while (type == Lexeme::BrokenComment || type == Lexeme::Comment || type == Lexeme::BlockComment || type == Lexeme::Whitespace)
     {
@@ -3598,7 +3598,7 @@ void Parser::nextLexeme()
             hotcomments.push_back({hotcommentHeader, lexeme.location, std::string(text + 1, text + end)});
         }
 
-        type = lexer.next(/* skipTrivia= */ false, /* updatePrevLocation= */ false).type;
+        type = lexer.next(/* skipComments= */ false, /* updatePrevLocation= */ false).type;
     }
 }
 

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -3572,7 +3572,7 @@ AstTypeError* Parser::reportMissingTypeError(const Location& parseErrorLocation,
 
 void Parser::nextLexeme()
 {
-    Lexeme::Type type = lexer.next(/* skipComments= */ false, true).type;
+    Lexeme::Type type = lexer.next(/* skipComments= */ false, /* skipWhitespace= */ false, true).type;
 
     while (type == Lexeme::BrokenComment || type == Lexeme::Comment || type == Lexeme::BlockComment || type == Lexeme::Whitespace)
     {
@@ -3598,7 +3598,7 @@ void Parser::nextLexeme()
             hotcomments.push_back({hotcommentHeader, lexeme.location, std::string(text + 1, text + end)});
         }
 
-        type = lexer.next(/* skipComments= */ false, /* updatePrevLocation= */ false).type;
+        type = lexer.next(/* skipComments= */ false, /* skipWhitespace= */ false, /* updatePrevLocation= */ false).type;
     }
 }
 

--- a/tests/Lexer.test.cpp
+++ b/tests/Lexer.test.cpp
@@ -256,9 +256,17 @@ TEST_CASE("lexer_tokenizes_whitespace")
     CHECK_EQ(lexer.next().type, Lexeme::ReservedLocal);
     CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
     CHECK_EQ(lexer.next().type, Lexeme::Name);
-    CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
+
+    auto space = lexer.next();
+    CHECK_EQ(space.type, Lexeme::Whitespace);
+    CHECK_EQ(std::string(space.data, space.getLength()), std::string(" "));
+
     CHECK_EQ(lexer.next().type, '=');
-    CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
+
+    auto space2 = lexer.next();
+    CHECK_EQ(space2.type, Lexeme::Whitespace);
+    CHECK_EQ(std::string(space2.data, space2.getLength()), std::string(" "));
+
     CHECK_EQ(lexer.next().type, Lexeme::Number);
     CHECK_EQ(lexer.next().type, Lexeme::Eof);
 }
@@ -278,13 +286,21 @@ TEST_CASE("lexer_tokenizes_multiline_whitespace")
     CHECK_EQ(lexer.next().type, Lexeme::ReservedLocal);
     CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
     CHECK_EQ(lexer.next().type, Lexeme::Name);
-    CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
+
+    auto multilineSpace = lexer.next();
+    CHECK_EQ(multilineSpace.type, Lexeme::Whitespace);
+    CHECK_EQ(std::string(multilineSpace.data, multilineSpace.getLength()), std::string("\n\n    "));
+
     CHECK_EQ(lexer.next().type, Lexeme::Name);
     CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
     CHECK_EQ(lexer.next().type, '=');
     CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
     CHECK_EQ(lexer.next().type, Lexeme::Number);
-    CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
+
+    auto multilineSpace2 = lexer.next();
+    CHECK_EQ(multilineSpace2.type, Lexeme::Whitespace);
+    CHECK_EQ(std::string(multilineSpace2.data, multilineSpace2.getLength()), std::string("\n    "));
+
     CHECK_EQ(lexer.next().type, Lexeme::Eof);
 }
 

--- a/tests/Lexer.test.cpp
+++ b/tests/Lexer.test.cpp
@@ -252,6 +252,7 @@ TEST_CASE("lexer_tokenizes_whitespace")
     Luau::Allocator alloc;
     AstNameTable table(alloc);
     Lexer lexer(testInput.c_str(), testInput.size(), table);
+    lexer.setSkipWhitespace(false);
 
     CHECK_EQ(lexer.next().type, Lexeme::ReservedLocal);
     CHECK_EQ(lexer.next().type, Lexeme::Whitespace);
@@ -282,6 +283,7 @@ TEST_CASE("lexer_tokenizes_multiline_whitespace")
     Luau::Allocator alloc;
     AstNameTable table(alloc);
     Lexer lexer(testInput.c_str(), testInput.size(), table);
+    lexer.setSkipWhitespace(false);
 
     CHECK_EQ(lexer.next().type, Lexeme::ReservedLocal);
     CHECK_EQ(lexer.next().type, Lexeme::Whitespace);

--- a/tests/Lexer.test.cpp
+++ b/tests/Lexer.test.cpp
@@ -40,7 +40,7 @@ TEST_CASE("broken_comment_kept")
     Luau::Allocator alloc;
     AstNameTable table(alloc);
     Lexer lexer(testInput.c_str(), testInput.size(), table);
-    lexer.setSkipTrivia(true);
+    lexer.setSkipComments(true);
     CHECK_EQ(lexer.next().type, Lexeme::Type::BrokenComment);
 }
 
@@ -50,7 +50,7 @@ TEST_CASE("comment_skipped")
     Luau::Allocator alloc;
     AstNameTable table(alloc);
     Lexer lexer(testInput.c_str(), testInput.size(), table);
-    lexer.setSkipTrivia(true);
+    lexer.setSkipComments(true);
     CHECK_EQ(lexer.next().type, Lexeme::Type::Eof);
 }
 
@@ -105,7 +105,7 @@ TEST_CASE("lookahead")
     Luau::Allocator alloc;
     AstNameTable table(alloc);
     Lexer lexer(testInput.c_str(), testInput.size(), table);
-    lexer.setSkipTrivia(true);
+    lexer.setSkipComments(true);
     lexer.next(); // must call next() before reading data from lexer at least once
 
     CHECK_EQ(lexer.current().type, Lexeme::Name);


### PR DESCRIPTION
We would like to develop tooling that can consume the syntax tree and perform transformations whilst preserving the underlying structure of the source code. This requires the lexer / parser to retain enough information to be able to re-print the original code.

The first step towards this is to ensure the lexer preserves the input structure. In this commit, we enable tokenization of whitespace, stored in a new Lexeme of type `Whitespace`. Multiline whitespace is all stored in a single Lexeme.