### PR TITLE
Allow table.clone to copy tables with locked metatables

### DIFF
--- a/CodeGen/src/NativeState.h
+++ b/CodeGen/src/NativeState.h
@@ -49,7 +49,7 @@ struct NativeContext
 
     int (*luaH_getn)(Table* t) = nullptr;
     Table* (*luaH_new)(lua_State* L, int narray, int lnhash) = nullptr;
-    Table* (*luaH_clone)(lua_State* L, Table* tt) = nullptr;
+    Table* (*luaH_clone)(lua_State* L, Table* tt, bool raw) = nullptr;
     void (*luaH_resizearray)(lua_State* L, Table* t, int nasize) = nullptr;
     TValue* (*luaH_setnum)(lua_State* L, Table* t, int key);
 

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -807,7 +807,7 @@ Table* luaH_clone(lua_State* L, Table* tt, bool raw)
     t->node = cast_to(LuaNode*, dummynode);
     t->lastfree = 0;
 
-    if (raw) // Prevent unauthorized assigning of locked metatables
+    if (!raw) // Prevent unauthorized assigning of locked metatables
         t->metatable = tt->metatable;
 
     if (tt->sizearray)

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -797,7 +797,6 @@ Table* luaH_clone(lua_State* L, Table* tt)
 {
     Table* t = luaM_newgco(L, Table, sizeof(Table), L->activememcat);
     luaC_init(L, t, LUA_TTABLE);
-    t->metatable = tt->metatable;
     t->tmcache = tt->tmcache;
     t->array = NULL;
     t->sizearray = 0;
@@ -807,6 +806,9 @@ Table* luaH_clone(lua_State* L, Table* tt)
     t->safeenv = 0;
     t->node = cast_to(LuaNode*, dummynode);
     t->lastfree = 0;
+
+    if (!luaL_getmetafield(L, 1, "__metatable"))
+        t->metatable = tt->metatable;
 
     if (tt->sizearray)
     {

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -807,7 +807,7 @@ Table* luaH_clone(lua_State* L, Table* tt)
     t->node = cast_to(LuaNode*, dummynode);
     t->lastfree = 0;
 
-    if (!luaL_getmetafield(L, 1, "__metatable"))
+    if (!luaL_getmetafield(L, 1, "__metatable")) // Prevent unauthorized assigning of locked metatables
         t->metatable = tt->metatable;
 
     if (tt->sizearray)

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -793,7 +793,7 @@ int luaH_getn(Table* t)
     }
 }
 
-Table* luaH_clone(lua_State* L, Table* tt)
+Table* luaH_clone(lua_State* L, Table* tt, bool raw)
 {
     Table* t = luaM_newgco(L, Table, sizeof(Table), L->activememcat);
     luaC_init(L, t, LUA_TTABLE);
@@ -807,7 +807,7 @@ Table* luaH_clone(lua_State* L, Table* tt)
     t->node = cast_to(LuaNode*, dummynode);
     t->lastfree = 0;
 
-    if (!luaL_getmetafield(L, 1, "__metatable")) // Prevent unauthorized assigning of locked metatables
+    if (raw) // Prevent unauthorized assigning of locked metatables
         t->metatable = tt->metatable;
 
     if (tt->sizearray)

--- a/VM/src/ltable.h
+++ b/VM/src/ltable.h
@@ -27,7 +27,7 @@ LUAI_FUNC void luaH_resizehash(lua_State* L, Table* t, int nhsize);
 LUAI_FUNC void luaH_free(lua_State* L, Table* t, struct lua_Page* page);
 LUAI_FUNC int luaH_next(lua_State* L, Table* t, StkId key);
 LUAI_FUNC int luaH_getn(Table* t);
-LUAI_FUNC Table* luaH_clone(lua_State* L, Table* tt);
+LUAI_FUNC Table* luaH_clone(lua_State* L, Table* tt, bool raw);
 LUAI_FUNC void luaH_clear(Table* tt);
 
 #define luaH_setslot(L, t, slot, key) (invalidateTMcache(t), (slot == luaO_nilobject ? luaH_newkey(L, t, key) : cast_to(TValue*, slot)))

--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -585,7 +585,7 @@ static int tisfrozen(lua_State* L)
 static int tclone(lua_State* L)
 {
     luaL_checktype(L, 1, LUA_TTABLE);
-    Table* tt = luaH_clone(L, hvalue(L->base));
+    Table* tt = luaH_clone(L, hvalue(L->base), luaL_getmetafield(L, 1, "__metatable") ? true : false);
     TValue v;
     sethvalue(L, &v, tt);
     luaA_pushobject(L, &v);

--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -585,10 +585,7 @@ static int tisfrozen(lua_State* L)
 static int tclone(lua_State* L)
 {
     luaL_checktype(L, 1, LUA_TTABLE);
-    luaL_argcheck(L, !luaL_getmetafield(L, 1, "__metatable"), 1, "table has a protected metatable");
-
     Table* tt = luaH_clone(L, hvalue(L->base));
-
     TValue v;
     sethvalue(L, &v, tt);
     luaA_pushobject(L, &v);


### PR DESCRIPTION
Implements RFC https://github.com/luau-lang/rfcs/pull/88

I haven't finished the RFC yet, but once I have, and if/when it gets accepted this can be merged. I'm keeping this as a draft for now as the RFC isn't merged yet. If there are any issues please let me know thanks.
