### PR TITLE
Fixup desync between internal and external codebases

### DIFF
--- a/Analysis/src/Differ.cpp
+++ b/Analysis/src/Differ.cpp
@@ -13,7 +13,6 @@
 
 namespace Luau
 {
-
 std::string DiffPathNode::toString() const
 {
     switch (kind)
@@ -945,13 +944,11 @@ std::vector<std::pair<TypeId, TypeId>>::const_reverse_iterator DifferEnvironment
     return visitingStack.crend();
 }
 
-
 DifferResult diff(TypeId ty1, TypeId ty2)
 {
     DifferEnvironment differEnv{ty1, ty2, std::nullopt, std::nullopt};
     return diffUsingEnv(differEnv, ty1, ty2);
 }
-
 
 DifferResult diffWithSymbols(TypeId ty1, TypeId ty2, std::optional<std::string> symbol1, std::optional<std::string> symbol2)
 {

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -2,9 +2,9 @@
 #include "Luau/BuiltinDefinitions.h"
 
 LUAU_FASTFLAGVARIABLE(LuauVectorDefinitionsExtra)
-LUAU_FASTFLAG(LuauVector2Constructor)
 LUAU_FASTFLAG(LuauBufferBitMethods2)
 LUAU_FASTFLAGVARIABLE(LuauMathMapDefinition)
+LUAU_FASTFLAG(LuauVector2Constructor)
 
 namespace Luau
 {


### PR DESCRIPTION
During conflict resolution while transferring patches back and forth, some conflict resolutions may cause code differences.

This process would have also cleaned up differences noted in https://github.com/luau-lang/luau/pull/1621
