### PR TITLE
Update minimal Ubuntu version in workflows from 20.04 to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         Debug/luau-compile tests/conformance/assert.lua
 
   coverage:
-    runs-on: ubuntu-20.04 # needed for clang++-10 to avoid gcov compatibility issues
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: install
@@ -94,7 +94,7 @@ jobs:
         sudo apt install llvm
     - name: make coverage
       run: |
-        CXX=clang++-10 make -j2 config=coverage native=1 coverage
+        CXX=clang++ make -j2 config=coverage native=1 coverage
     - name: upload coverage
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -29,8 +29,8 @@ jobs:
   build:
     needs: ["create-release"]
     strategy:
-      matrix: # using ubuntu-20.04 to build a Linux binary targeting older glibc to improve compatibility
-        os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
+      matrix: # not using ubuntu-latest to improve compatibility
+        os: [{name: ubuntu, version: ubuntu-22.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   build:
     strategy:
-      matrix: # using ubuntu-20.04 to build a Linux binary targeting older glibc to improve compatibility
-        os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
+      matrix: # not using ubuntu-latest to improve compatibility
+        os: [{name: ubuntu, version: ubuntu-22.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
     steps:


### PR DESCRIPTION
Ubuntu 20.04 LTS is reaching the end of its standard support period.
GitHub runners are going to stop providing images for it soon.

This PR updates all workflows to use 22.04 instead of 20.04.
While this will impact the compatibility of prebuilt release binaries on 20.04, users of those systems can always build Luau from source.

`coverage` workflow is also updating from clang++10 to clang++ (defaults to clang++14 today).
Line coverage with this switch drops from 89.65% to 87.45%, function coverage remains 91.26%.
As a bonus, we now get branch coverage information.