### PR TITLE
Fix the order of the arguments being inputted into result.append in print() from the Type Function Runtime

### DIFF
--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -15,6 +15,7 @@
 
 LUAU_DYNAMIC_FASTINT(LuauTypeFunctionSerdeIterationLimit)
 LUAU_FASTFLAGVARIABLE(LuauUserTypeFunTypeofReturnsType)
+LUAU_FASTFLAGVARIABLE(LuauTypeFunPrintFix)
 
 namespace Luau
 {
@@ -1610,7 +1611,12 @@ static int print(lua_State* L)
         size_t l = 0;
         const char* s = luaL_tolstring(L, i, &l); // convert to string using __tostring et al
         if (i > 1)
-            result.append('\t', 1);
+        {
+            if (FFlag::LuauTypeFunPrintFix)
+                result.append(1, '\t');
+            else
+                result.append('\t', 1);
+        }
         result.append(s, l);
         lua_pop(L, 1);
     }

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -1900,6 +1900,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_print_tab_char_fix")
         local _:test<number>
     )");
 
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+
     // It should be \t and not \x1
     CHECK_EQ("1\t2", toString(result.errors[0]));
 }

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -10,6 +10,7 @@ using namespace Luau;
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(DebugLuauEqSatSimplification)
 LUAU_FASTFLAG(LuauUserTypeFunTypeofReturnsType)
+LUAU_FASTFLAG(LuauTypeFunPrintFix)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");
 
@@ -1883,6 +1884,24 @@ local _:test<number>
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(toString(result.errors[0]) == R"(type)");
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_print_tab_char_fix")
+{
+    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}, {FFlag::LuauTypeFunPrintFix, true}};
+
+    CheckResult result = check(R"(
+        type function test(t)
+            print(1,2)
+
+            return t
+        end
+
+        local _:test<number>
+    )");
+
+    // It should be \t and not \x1
+    CHECK_EQ("1\t2", toString(result.errors[0]));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This fixes ``print`` from the Type Function Runtime, when you use ``,`` inside of ``print()`` within a type function.

**Currently**, in the Type Function Runtime, if you do ``print(1, 2)``

It's going to append ``\x1`` based on the ``size_t`` of ``\t``, because it's in the **wrong function argument order**.

It's not going to use ``\t`` instead it creates ``\x1`` because of a copy paste mistake from the original ``print``

``result.append`` has a different function order


![image](https://github.com/user-attachments/assets/90e65de1-34dd-4c66-88d2-33331d03ec25)

Currently, it's the wrong order


This is the right way

![image](https://github.com/user-attachments/assets/ac576ab2-811e-4e06-ad7a-1a82b9d5e69c)


&nbsp;


**Before:**
![image](https://github.com/user-attachments/assets/e61eab72-d836-4226-b850-4cdd99939c1a)


**After:**
![image](https://github.com/user-attachments/assets/b08ade46-4cd4-43f5-86ef-bebe18537236)
