### PR TITLE
Lexer: add offset getter

### DIFF
--- a/Ast/include/Luau/Lexer.h
+++ b/Ast/include/Luau/Lexer.h
@@ -187,6 +187,11 @@ public:
     static bool fixupQuotedString(std::string& data);
     static void fixupMultilineString(std::string& data);
 
+    unsigned int getOffset() const
+    {
+        return offset;
+    }
+
 private:
     char peekch() const;
     char peekch(unsigned int lookahead) const;


### PR DESCRIPTION
Added a getter for the Lexer's private `offset` to track its cursor position in the buffer.
This helps me index tokens by buffer address in a project where I'm rendering Luau code with [Dear ImGui](https://github.com/ocornut/imgui).
Would love this merged so I can use official Luau releases again!