### PR TITLE
Add #include <stdint.h> to fix building with gcc 15

### DIFF
--- a/Analysis/src/TypedAllocator.cpp
+++ b/Analysis/src/TypedAllocator.cpp
@@ -26,6 +26,8 @@ const size_t kPageSize = sysconf(_SC_PAGESIZE);
 
 #include <stdlib.h>
 
+#include <cstdint>
+
 LUAU_FASTFLAG(DebugLuauFreezeArena)
 
 namespace Luau

--- a/Analysis/src/TypedAllocator.cpp
+++ b/Analysis/src/TypedAllocator.cpp
@@ -24,9 +24,8 @@ const size_t kPageSize = sysconf(_SC_PAGESIZE);
 #endif
 #endif
 
+#include <stdint.h>
 #include <stdlib.h>
-
-#include <cstdint>
 
 LUAU_FASTFLAG(DebugLuauFreezeArena)
 


### PR DESCRIPTION
With gcc 15, the C++ Standard Library no longer includes other headers that were internally used by the library. In Luau's case the missing header is `<stdint.h>`

Downstream Gentoo bug: https://bugs.gentoo.org/938122
Signed-off-by: Kostadin Shishmanov <kostadinshishmanov@protonmail.com>