### PR TITLE
fix parsing string union indexers

### DIFF
--- a/Ast/include/Luau/Parser.h
+++ b/Ast/include/Luau/Parser.h
@@ -228,9 +228,9 @@ private:
         Position colonPosition;
     };
 
-    TableIndexerResult parseTableIndexer(AstTableAccess access, std::optional<Location> accessLocation);
+    TableIndexerResult parseTableIndexer(AstTableAccess access, std::optional<Location> accessLocation, Lexeme begin);
     // Remove with FFlagLuauStoreCSTData
-    AstTableIndexer* parseTableIndexer_DEPRECATED(AstTableAccess access, std::optional<Location> accessLocation);
+    AstTableIndexer* parseTableIndexer_DEPRECATED(AstTableAccess access, std::optional<Location> accessLocation, Lexeme begin);
 
     AstTypeOrPack parseFunctionType(bool allowPack, const AstArray<AstAttr*>& attributes);
     AstType* parseFunctionTypeTail(

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1395,7 +1395,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
                             // the last param in the parseTableIndexer is ignored since FFlagLuauParseStringIndexer is false here
                             indexer = parseTableIndexer(AstTableAccess::ReadWrite, std::nullopt, lexer.current()).node;
                         else
-                            // the last param in the parseTableIndexer is ignored
+                            // the last param in the parseTableIndexer is ignored since FFlagLuauParseStringIndexer is false here
                             indexer = parseTableIndexer_DEPRECATED(AstTableAccess::ReadWrite, std::nullopt, lexer.current());
                     }
                 }

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1383,7 +1383,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
                             // the last param in the parseTableIndexer is ignored since FFlagLuauParseStringIndexer is false here
                             badIndexer = parseTableIndexer(AstTableAccess::ReadWrite, std::nullopt, lexer.current()).node;
                         else
-                            // the last param in the parseTableIndexer is ignored
+                            // the last param in the parseTableIndexer is ignored since FFlagLuauParseStringIndexer is false here
                             badIndexer = parseTableIndexer_DEPRECATED(AstTableAccess::ReadWrite, std::nullopt, lexer.current());
 
                         // we lose all additional indexer expressions from the AST after error recovery here

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1380,7 +1380,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
                         // however, we either have { or [ to lint, not the entire table type or the bad indexer.
                         AstTableIndexer* badIndexer;
                         if (FFlag::LuauStoreCSTData)
-                            // the last param in the parseTableIndexer is ignored
+                            // the last param in the parseTableIndexer is ignored since FFlagLuauParseStringIndexer is false here
                             badIndexer = parseTableIndexer(AstTableAccess::ReadWrite, std::nullopt, lexer.current()).node;
                         else
                             // the last param in the parseTableIndexer is ignored

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1392,7 +1392,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
                     else
                     {
                         if (FFlag::LuauStoreCSTData)
-                            // the last param in the parseTableIndexer is ignored
+                            // the last param in the parseTableIndexer is ignored since FFlagLuauParseStringIndexer is false here
                             indexer = parseTableIndexer(AstTableAccess::ReadWrite, std::nullopt, lexer.current()).node;
                         else
                             // the last param in the parseTableIndexer is ignored

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -3938,5 +3938,9 @@ TEST_CASE_FIXTURE(Fixture, "parsing_type_suffix_for_return_type_with_variadic")
     CHECK(result.errors.size() == 0);
 }
 
+TEST_CASE_FIXTURE(Fixture, "parsing_string_union_indexers")
+{
+    parse(R"(type foo = { ["bar" | "baz"]: number })");
+}
 
 TEST_SUITE_END();

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -24,6 +24,7 @@ LUAU_FASTFLAG(LuauPreserveUnionIntersectionNodeForLeadingTokenSingleType)
 LUAU_FASTFLAG(LuauAstTypeGroup3)
 LUAU_FASTFLAG(LuauFixDoBlockEndLocation)
 LUAU_FASTFLAG(LuauParseOptionalAsNode)
+LUAU_FASTFLAG(LuauParseStringIndexer)
 
 namespace
 {
@@ -3940,6 +3941,7 @@ TEST_CASE_FIXTURE(Fixture, "parsing_type_suffix_for_return_type_with_variadic")
 
 TEST_CASE_FIXTURE(Fixture, "parsing_string_union_indexers")
 {
+    ScopedFastFlag _{FFlag::LuauParseStringIndexer, true};
     parse(R"(type foo = { ["bar" | "baz"]: number })");
 }
 


### PR DESCRIPTION
Today this code results in a syntax error: `type foo = { ["bar" | "baz"]: number }`. This is odd and I believe it is a bug. I have fixed this so that it is now parsed as an indexer field with a union type. This change should not affect the way any code is parsed today, and  allow types in indexers to begin with string literals.