### PR TITLE
Enable the A64 unwinding test

### DIFF
--- a/tests/CodeAllocator.test.cpp
+++ b/tests/CodeAllocator.test.cpp
@@ -832,7 +832,6 @@ TEST_CASE("GeneratedCodeExecutionA64")
     CHECK(result == 42);
 }
 
-#if 0
 static void throwing(int64_t arg)
 {
     CHECK(arg == 25);
@@ -915,7 +914,6 @@ TEST_CASE("GeneratedCodeExecutionWithThrowA64")
         CHECK(strcmp(error.what(), "testing") == 0);
     }
 }
-#endif
 
 #endif
 


### PR DESCRIPTION
This was disabled in 575 sync because of a CI problem, but it's fine now.