### PR TITLE
Do not store file extensions in module chunknames [Luau CLI]

### DIFF
--- a/CLI/src/Repl.cpp
+++ b/CLI/src/Repl.cpp
@@ -581,7 +581,14 @@ static bool runFile(const char* name, lua_State* GL, bool repl)
     // new thread needs to have the globals sandboxed
     luaL_sandboxthread(L);
 
-    std::string chunkname = "@" + std::string(name);
+    // ignore file extension when storing module's chunkname
+    std::string chunkname = "@";
+    std::string_view nameView = name;
+    if (size_t dotPos = nameView.find_last_of('.'); dotPos != std::string_view::npos)
+    {
+        nameView.remove_suffix(nameView.size() - dotPos);
+    }
+    chunkname += nameView;
 
     std::string bytecode = Luau::compile(*source, copts());
     int status = 0;


### PR DESCRIPTION
The Luau CLI's require implementation was moved to the new `Luau.Require` library in release 0.669.

In this implementation, chunknames correspond to abstract module paths (not exact filesystems paths), and this is enforced throughout the require-by-string algorithm whenever a newly required module's chunkname is created. The only place this is not being enforced is at the entry point of the Luau CLI: the chunkname of the given file still includes its file extension, which breaks the invariant expected by the require-by-string implementation.

This PR removes that file extension from the entry point's chunkname.

Fixes #1771.