### PR TITLE
Disable `LuauNonReentrantGeneralization` for `Linter/TableOperations`

### DIFF
--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -10,6 +10,7 @@
 LUAU_FASTFLAG(LuauSolverV2);
 LUAU_FASTFLAG(LintRedundantNativeAttribute);
 LUAU_FASTFLAG(LuauDeprecatedAttribute);
+LUAU_FASTFLAG(LuauNonReentrantGeneralization);
 
 using namespace Luau;
 
@@ -1923,6 +1924,9 @@ print(foo:bar(2.0))
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "TableOperations")
 {
+    // FIXME: For now this flag causes a stack overflow on Windows.
+    ScopedFastFlag _{FFlag::LuauNonReentrantGeneralization, false};
+
     LintResult result = lint(R"(
 local t = {}
 local tt = {}

--- a/tests/Normalize.test.cpp
+++ b/tests/Normalize.test.cpp
@@ -21,6 +21,7 @@ LUAU_FASTFLAG(LuauSubtypingStopAtNormFail)
 LUAU_FASTFLAG(LuauNormalizationCatchMetatableCycles)
 LUAU_FASTFLAG(LuauSubtypingEnableReasoningLimit)
 LUAU_FASTFLAG(LuauTypePackDetectCycles)
+LUAU_FASTFLAG(LuauNonreentrantGeneralization)
 
 using namespace Luau;
 
@@ -1219,6 +1220,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "fuzz_propagate_normalization_failures")
     ScopedFastFlag luauNormalizeLimitFunctionSet{FFlag::LuauNormalizeLimitFunctionSet, true};
     ScopedFastFlag luauSubtypingStopAtNormFail{FFlag::LuauSubtypingStopAtNormFail, true};
     ScopedFastFlag luauSubtypingEnableReasoningLimit{FFlag::LuauSubtypingEnableReasoningLimit, true};
+    ScopedFastFlag luauTurnOffNonreentrantGeneralization{FFlag::LuauNonReentrantGeneralization, false};
 
     CheckResult result = check(R"(
 function _(_,"").readu32(l0)

--- a/tests/Normalize.test.cpp
+++ b/tests/Normalize.test.cpp
@@ -21,7 +21,7 @@ LUAU_FASTFLAG(LuauSubtypingStopAtNormFail)
 LUAU_FASTFLAG(LuauNormalizationCatchMetatableCycles)
 LUAU_FASTFLAG(LuauSubtypingEnableReasoningLimit)
 LUAU_FASTFLAG(LuauTypePackDetectCycles)
-LUAU_FASTFLAG(LuauNonreentrantGeneralization)
+LUAU_FASTFLAG(LuauNonReentrantGeneralization)
 
 using namespace Luau;
 

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -34,6 +34,7 @@ LUAU_FASTFLAG(LuauTypeCheckerAcceptNumberConcats)
 LUAU_FASTFLAG(LuauPreprocessTypestatedArgument)
 LUAU_FASTFLAG(LuauCacheInferencePerAstExpr)
 LUAU_FASTFLAG(LuauMagicFreezeCheckBlocked)
+LUAU_FASTFLAG(LuauNonReentrantGeneralization)
 
 using namespace Luau;
 
@@ -433,14 +434,15 @@ TEST_CASE_FIXTURE(Fixture, "check_block_recursion_limit")
 TEST_CASE_FIXTURE(Fixture, "check_expr_recursion_limit")
 {
 #if defined(LUAU_ENABLE_ASAN)
-    int limit = 250;
+    int limit = 200;
 #elif defined(_DEBUG) || defined(_NOOPT)
-    int limit = 300;
+    int limit = 250;
 #else
-    int limit = 600;
+    int limit = 500;
 #endif
     ScopedFastInt luauRecursionLimit{FInt::LuauRecursionLimit, limit + 100};
     ScopedFastInt luauCheckRecursionLimit{FInt::LuauCheckRecursionLimit, limit - 100};
+    ScopedFastFlag _{FFlag::LuauNonReentrantGeneralization, false};
 
     CheckResult result = check(R"(("foo"))" + rep(":lower()", limit));
 


### PR DESCRIPTION
For now, this flag causes a stack overflow for this specific test on Windows: we end up minting a massive recursive intersection during generalization. Let's flip it off until a fix arrives.