### PR TITLE
Fix crash when `require` is called from root VM stack

### DIFF
--- a/Require/Runtime/src/RequireImpl.cpp
+++ b/Require/Runtime/src/RequireImpl.cpp
@@ -170,7 +170,8 @@ int lua_proxyrequire(lua_State* L)
 int lua_require(lua_State* L)
 {
     lua_Debug ar;
-    lua_getinfo(L, 1, "s", &ar);
+    if (!lua_getinfo(L, 1, "s", &ar))
+        luaL_error(L, "require is not supported in this context");
     return lua_requireinternal(L, ar.source);
 }
 


### PR DESCRIPTION
Copied from #1785:
> If require is called from the root interpreter stack (e.g. using C API) then lua_getinfo call will not succeed, leaving garbage in lua_Debug ar struct.
> Accessing later ar.source as null-terminated string is unsafe and can cause a crash.
> 
> This PR adds a check to ensure that lua_getinfo call is successful.