### PR TITLE
Fix the fuzzer being built even if LUAU_BUILD_TESTS is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ if(LUAU_BUILD_TESTS)
     target_link_libraries(Luau.CLI.Test PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.VM Luau.Require Luau.CLI.lib isocline)
     target_link_libraries(Luau.CLI.Test PRIVATE osthreads)
 
+    add_subdirectory(fuzz)
 endif()
 
 if(LUAU_BUILD_WEB)
@@ -281,8 +282,6 @@ if(LUAU_BUILD_WEB)
     # the output is a single .js file with an embedded wasm blob
     target_link_options(Luau.Web PRIVATE -sSINGLE_FILE=1)
 endif()
-
-add_subdirectory(fuzz)
 
 # validate dependencies for internal libraries
 foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.CodeGen Luau.VM)


### PR DESCRIPTION
This PR fixes the fuzzer always being built even when LUAU_BUILD_TESTS is off. This is done by moving the `include_subdirectory` for the fuzzer inside of the if block under LUAU_BUILD_TESTS.