### PR TITLE
Add missing cpp header

### DIFF
--- a/CLI/src/Web.cpp
+++ b/CLI/src/Web.cpp
@@ -6,6 +6,7 @@
 #include "Luau/Common.h"
 
 #include <string>
+#include <memory>
 
 #include <string.h>
 


### PR DESCRIPTION
While working on a custom build system, I noticed the Web.cpp file inside the CLI folder is missing a simple header include!