### PR TITLE
Fix gcinfo() and collectgarbage("count") to return floating-point KB values

### DIFF
--- a/CLI/src/Repl.cpp
+++ b/CLI/src/Repl.cpp
@@ -126,8 +126,9 @@ static int lua_collectgarbage(lua_State* L)
 
     if (strcmp(option, "count") == 0)
     {
-        int c = lua_gc(L, LUA_GCCOUNT, 0);
-        lua_pushnumber(L, c);
+        int k = lua_gc(L, LUA_GCCOUNT, 0);
+        int b = lua_gc(L, LUA_GCCOUNTB, 0);
+        lua_pushnumber(L, double(k) + double(b) / 1024);
         return 1;
     }
 

--- a/VM/src/lbaselib.cpp
+++ b/VM/src/lbaselib.cpp
@@ -191,7 +191,9 @@ static int luaB_rawlen(lua_State* L)
 
 static int luaB_gcinfo(lua_State* L)
 {
-    lua_pushinteger(L, lua_gc(L, LUA_GCCOUNT, 0));
+    int k = lua_gc(L, LUA_GCCOUNT, 0);
+    int b = lua_gc(L, LUA_GCCOUNTB, 0);
+    lua_pushnumber(L, (double)k + (double)b / 1024);
     return 1;
 }
 

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -73,6 +73,13 @@ static int lua_collectgarbage(lua_State* L)
     int res = lua_gc(L, optsnum[o], ex);
     switch (optsnum[o])
     {
+    case LUA_GCCOUNT:
+    {
+        int k = lua_gc(L, LUA_GCCOUNT, 0);
+        int b = lua_gc(L, LUA_GCCOUNTB, 0);
+        lua_pushnumber(L, double(k) + double(b) / 1024);
+        return 1;
+    }
     case LUA_GCSTEP:
     case LUA_GCISRUNNING:
     {


### PR DESCRIPTION
Summary:
Both gcinfo() and collectgarbage("count") were returning truncated integer values instead of floating-point KB measurements, breaking compatibility with standard Lua implementations which preserve fractional bytes in their output.
Fixes #1917

Changes:
- Modified gcinfo() and collectgarbage("count") to return full precision floating-point value
- Updated return type from integer to double/number for both functions

Before:
- gcinfo() -> 36 (integer)
- collectgarbage("count") -> 36 (integer)

After:
- gcinfo() -> 36.30859375 (double)
- collectgarbage("count") -> 36.30859375 (double)
- 1024 * 36.30859375 = 37180 (integer value in bytes)