### PR TITLE
Implement RFC, rename "class" to "extern" locked behind a debug flag - by replacing function pointers

### DIFF
--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -13,6 +13,7 @@ LUAU_FASTFLAG(LuauEagerGeneralization4)
 LUAU_FASTFLAG(LuauTableLiteralSubtypeSpecificCheck2)
 LUAU_FASTFLAG(LuauStuckTypeFunctionsStillDispatch)
 LUAU_FASTFLAG(LuauTypeFunctionSerializeFollowMetatable)
+LUAU_FASTFLAG(LuauDeclareExternType)
 LUAU_FASTFLAG(DebugLuauRenameClassToExtern)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -2504,7 +2504,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_extern_tag")
 
     CheckResult result = check(R"(
         --!strict
-        type function tyFunc(arg): any
+        type function tyFunc(arg: type)
             if (arg:is("extern")) then
                 return arg
             end

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -13,6 +13,7 @@ LUAU_FASTFLAG(LuauEagerGeneralization4)
 LUAU_FASTFLAG(LuauTableLiteralSubtypeSpecificCheck2)
 LUAU_FASTFLAG(LuauStuckTypeFunctionsStillDispatch)
 LUAU_FASTFLAG(LuauTypeFunctionSerializeFollowMetatable)
+LUAU_FASTFLAG(DebugLuauRenameClassToExtern)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");
 
@@ -2484,6 +2485,39 @@ end
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(toString(result.errors[0]) == R"(Redefinition of type 't0', previously defined at line 2)");
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_extern_tag")
+{
+    ScopedFastFlag sff[]{
+        {FFlag::LuauSolverV2, true},
+        {FFlag::DebugLuauRenameClassToExtern, true}
+    };
+
+    loadDefinition(R"(
+        declare extern type CustomExternType with
+            function testFunc(self): number
+        end
+    )");
+
+    CheckResult result = check(R"(
+        --!strict
+        type function tyFunc(arg): any
+            if (arg:is("extern")) then
+                return arg
+            end
+            -- this should never be returned
+            return types.boolean
+        end
+        
+        type a = tyFunc<CustomExternType>
+    )");
+
+    auto test = requireTypeAlias("a");
+    // If it's not an ExternType it will fail.
+    LUAU_ASSERT( test->ty.get_if<ExternType>() );
+
+    LUAU_REQUIRE_NO_ERRORS(result);
 }
 
 TEST_SUITE_END();

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -2492,6 +2492,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_extern_tag")
 {
     ScopedFastFlag sff[]{
         {FFlag::LuauSolverV2, true},
+	{FFlag::LuauDeclareExternType, true},
         {FFlag::DebugLuauRenameClassToExtern, true}
     };
 


### PR DESCRIPTION
Implementation for https://github.com/luau-lang/rfcs/pull/131 incase it gets merged

This is variation 1.

Variation 2 is here: https://github.com/luau-lang/luau/pull/1927


In this variation I **replaced the functions**. And the feature is locked behind ``FFlagDebugLuauRenameClassToExtern``, it's prefixed with Debug, so it doesn't get enabled by ``--fflags=true``, which allows us to transition to get rid of every existing reference of ``"class"``.

The reason why I replace functions in this variation, is because I thought that this is the optimal way, and won't add an extra instruction everytime you'd call ``:is``