### PR TITLE
Add missing documentation for FORGPREP_INEXT and FORGPREP_NEXT

### DIFF
--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -298,6 +298,7 @@ enum LuauOpcode
 
     // FORGPREP_INEXT: prepare FORGLOOP with 2 output variables (no AUX encoding), assuming generator is luaB_inext, and jump to FORGLOOP
     // A: target register (see FORGLOOP for register layout)
+    // D: jump offset (-32768..32767)
     LOP_FORGPREP_INEXT,
 
     // FASTCALL3: perform a fast call of a built-in function using 3 register arguments
@@ -310,6 +311,7 @@ enum LuauOpcode
 
     // FORGPREP_NEXT: prepare FORGLOOP with 2 output variables (no AUX encoding), assuming generator is luaB_next, and jump to FORGLOOP
     // A: target register (see FORGLOOP for register layout)
+    // D: jump offset (-32768..32767)
     LOP_FORGPREP_NEXT,
 
     // NATIVECALL: start executing new function in native code


### PR DESCRIPTION
Added documentation for FORGPREP_INEXT and FORGPREP_NEXT regarding the D argument, which is used as the jump offset to the corresponding FORGLOOP instruction.