### PR TITLE
Add AstStatDeclareFunction to the Transpiler and fix AstStatDeclareFunction location issue with attributes

### DIFF
--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1240,7 +1240,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
             newStart = attributes.data[0]->location;
 
         return allocator.alloc<AstStatDeclareFunction>(
-            Location(start, end),
+            Location(newStart, end),
             attributes,
             globalName.name,
             globalName.location,

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1234,6 +1234,11 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
         if (vararg && !varargAnnotation)
             return reportStatError(Location(start, end), {}, {}, "All declaration parameters must be annotated");
 
+        // If there are attributes, set the location start to the first attribute's location.
+        Location newStart = start;
+        if (attributes.size > 0)
+            newStart = attributes.data[0]->location;
+
         return allocator.alloc<AstStatDeclareFunction>(
             Location(start, end),
             attributes,

--- a/tests/Transpiler.test.cpp
+++ b/tests/Transpiler.test.cpp
@@ -1584,6 +1584,25 @@ TEST_CASE_FIXTURE(Fixture, "transpile_declare_global_stat")
     CHECK_EQ(result, code);
 }
 
+TEST_CASE_FIXTURE(Fixture, "transpile_declare_function_stat")
+{
+    std::string code = R"(
+    @checked @deprecated declare function ABC<E, A..., R1..., R2...>(
+        f: (A...)-> R1..., err: (E)-> R2..., ...: number): (boolean, R1...)
+    )";
+
+    ParseOptions options;
+    options.allowDeclarationSyntax = true;
+
+    auto allocator = Allocator{};
+    auto names = AstNameTable{allocator};
+    ParseResult parseResult = Parser::parse(code.data(), code.size(), names, allocator, options);
+
+    auto result = transpileWithTypes(*parseResult.root);
+
+    CHECK_EQ(result, code);
+}
+
 TEST_CASE_FIXTURE(Fixture, "transpile_to_string")
 {
     std::string code = "local a: string = 'hello'";


### PR DESCRIPTION
How do you even properly commit a pull request, I am copy pasting manually, I am not even using ``git diff`` and I don't want to make a separate branch and swap to it to do a pull request, because it breaks my CMake, someone please tell me! 🙏 

Like, I literally copy pasted the code manually from Visual Studio into this PR. Because I cloned master, and made this changes on a modified branch of mine that has debug logging, but I don't want to PR the debug logging as well, only specific commits, so... yeah... 🤷 
Hence why, someone please tell me 🙏 


&nbsp;

Anyways, I commited, and I succeeded. That's because I was told what ``writer.advance`` does.

At the beginning I actually took this route: https://paste.ivr.fi/olulyniwah.cpp

&nbsp;

Except there's one thing it doesn't do, it doesn't know about ``(`` positions and it doesn't make a space àfter a ``->`` if there's no CstNode present.

This could be fixed in this pull request, simply by adding ``else`` like so, and have the Unit Test adjusted manually, but I don't know if I should, plus edit access is enabled.

```cpp
if (cstNode)
    advance(cstNode->returnArrowPosition);
else
    space();
```

Then I fixed this issue https://discord.com/channels/385151591524597761/906369439262461992/1399132629592309800

If there are Attributes present for ``AstStatDeclareFunction``. The AST node would not update the location to the beginning of the attribute's start location. This is fixed now.

Not fixing this would break the ``writer.advance`` and it took me a bit to figure this all out in the first place. :/
