### PR TITLE
Fix blocked-type leak when defining global with the same global name

### DIFF
--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -41,6 +41,7 @@ LUAU_FASTFLAG(DebugLuauMagicTypes)
 LUAU_FASTFLAG(LuauNewNonStrictSuppressSoloConstraintSolvingIncomplete)
 LUAU_FASTFLAG(LuauReturnMappedGenericPacksFromSubtyping2)
 LUAU_FASTFLAG(LuauMissingFollowMappedGenericPacks)
+LUAU_FASTFLAG(LuauFixPrepopulateGlobalOnSameGlobal)
 
 using namespace Luau;
 
@@ -2524,6 +2525,22 @@ TEST_CASE_FIXTURE(Fixture, "if_then_else_two_errors")
     REQUIRE(err2);
     CHECK_EQ("foo", toString(err2->wantedType));
     CHECK_EQ("number", toString(err2->givenType));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "prepopulate_globals_global_on_same_global_name_assign")
+{
+    ScopedFastFlag sff[]{
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauFixPrepopulateGlobalOnSameGlobal, true}
+    };
+
+    CheckResult result = check(R"(
+        --!strict
+        a = a
+        function a:test() end
+    )");
+
+    LUAU_CHECK_NO_ERROR(result, ConstraintSolvingIncompleteError);
 }
 
 TEST_CASE_FIXTURE(Fixture, "simplify_constraint_can_force")


### PR DESCRIPTION
Fixes

```lua
--!strict
a = a
function a:test() end
```

I was really struggling trying to find on what would be the correct fix. So much, that it made me mad, because there's no way for me to figure it out, unless I learn everything that is contained inside this repository, or something and understand it.

&nbsp;

This adds ``FFlagLuauFixPrepopulateGlobalOnSameGlobal``

If there's a
``a = a`` the rhs gets banned from the prepopulator.