### PR TITLE
Support octal integer literals

### DIFF
--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -3107,6 +3107,14 @@ private:
                 "Hexadecimal number literal exceeded available precision and was truncated to 2^64"
             );
             break;
+        case ConstantNumberParseResult::OctOverflow:
+            emitWarning(
+                *context,
+                LintWarning::Code_IntegerParsing,
+                node->location,
+                "Octal number literal exceeded available precision and was truncated to 2^64"
+            );
+            break;
         }
 
         return true;

--- a/Ast/include/Luau/Ast.h
+++ b/Ast/include/Luau/Ast.h
@@ -307,6 +307,7 @@ enum class ConstantNumberParseResult
     Malformed,
     BinOverflow,
     HexOverflow,
+    OctOverflow,
 };
 
 class AstExprConstantNumber : public AstExpr

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -2235,11 +2235,13 @@ TEST_CASE_FIXTURE(Fixture, "IntegerParsing")
     LintResult result = lint(R"(
 local _ = 0b10000000000000000000000000000000000000000000000000000000000000000
 local _ = 0x10000000000000000
+local _ = 0o2000000000000000000000
 )");
 
-    REQUIRE(2 == result.warnings.size());
+    REQUIRE(3 == result.warnings.size());
     CHECK_EQ(result.warnings[0].text, "Binary number literal exceeded available precision and was truncated to 2^64");
     CHECK_EQ(result.warnings[1].text, "Hexadecimal number literal exceeded available precision and was truncated to 2^64");
+    CHECK_EQ(result.warnings[2].text, "Octal number literal exceeded available precision and was truncated to 2^64");
 }
 
 TEST_CASE_FIXTURE(Fixture, "IntegerParsingDecimalImprecise")

--- a/tests/Transpiler.test.cpp
+++ b/tests/Transpiler.test.cpp
@@ -582,6 +582,12 @@ TEST_CASE("binary_numbers")
     CHECK_EQ(code, transpile(code).code);
 }
 
+TEST_CASE("octal_numbers")
+{
+    const std::string code = R"( local a = 0o777 )";
+    CHECK_EQ(code, transpile(code).code);
+}
+
 TEST_CASE("single_quoted_strings")
 {
     const std::string code = R"( local a = 'hello world' )";


### PR DESCRIPTION
Octal literals can be represented in the form 0o[0-7]

See https://github.com/luau-lang/rfcs/pull/133