### PR TITLE
[New Solver] Tentative fix for intersection types with optional functions

### DIFF
--- a/tests/TypeInfer.intersectionTypes.test.cpp
+++ b/tests/TypeInfer.intersectionTypes.test.cpp
@@ -1485,4 +1485,20 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "narrow_intersection_nevers")
     CHECK_EQ("Player & { read Character: ~(false?) }", toString(requireTypeAtPosition({3, 23})));
 }
 
+TEST_CASE_FIXTURE(Fixture, "intersection_of_tables_with_optional_functions")
+{
+    CheckResult result = check(R"(
+        type Drawing = { update: (() -> boolean)? }
+        type Counter = { count: number }
+        function create(): Drawing & Counter
+            return {
+                count = 34,
+                update = function() return true end
+            }
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Fix intersection types with optional functions, see issue #1935. 

- Add targeted fix for function <: function? compatibility in intersection types. A more generalized approach may be desirable here… This won’t work with overloaded optional functions like ```update: (() -> boolean)? | (()->number)?,``` which do work with the old solver.
- Add test case demonstrating the fix works correctly