### PR TITLE
Allow calls to vararg functions to be inlined if the number of arguments are known at compile-time (#1696)

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -294,7 +294,7 @@ struct Compiler
         f.upvals = upvals;
 
         // record information for inlining
-        if (options.optimizationLevel >= 2 && !func->vararg && !func->self && !getfenvUsed && !setfenvUsed)
+        if (options.optimizationLevel >= 2 && !func->self && !getfenvUsed && !setfenvUsed)
         {
             f.canInline = true;
             f.stackSize = stackSize;
@@ -594,6 +594,18 @@ struct Compiler
             return false;
         }
 
+        if (func->vararg)
+        {
+            for (AstExpr* arg : expr->args)
+            {
+                if (isExprMultRet(arg))
+                {
+                    bytecode.addDebugRemark("inlining failed: can't inline vararg function calls with multret arguments");
+                    return false;
+                }
+            }
+        }
+
         // compute constant bitvector for all arguments to feed the cost model
         bool varc[8] = {};
         for (size_t i = 0; i < func->args.size && i < expr->args.size && i < 8; ++i)
@@ -813,9 +825,7 @@ struct Compiler
             // add a debug remark for cases when we didn't even call tryCompileInlinedCall
             if (func && !(fi && fi->canInline))
             {
-                if (func->vararg)
-                    bytecode.addDebugRemark("inlining failed: function is variadic");
-                else if (!fi)
+                if (!fi)
                     bytecode.addDebugRemark("inlining failed: can't inline recursive calls");
                 else if (getfenvUsed || setfenvUsed)
                     bytecode.addDebugRemark("inlining failed: module uses getfenv/setfenv");

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -6289,7 +6289,7 @@ RETURN R1 1
 
 TEST_CASE("InlineProhibited")
 {
-    // we can't inline variadic functions
+    // we can inline variadic functions with fixedret arguments
     CHECK_EQ(
         "\n" + compileFunction(
                    R"(
@@ -6305,9 +6305,32 @@ return x
                ),
         R"(
 DUPCLOSURE R0 K0 ['foo']
-MOVE R1 R0
-CALL R1 0 1
+LOADN R1 42
 RETURN R1 1
+)"
+    );
+
+    // we can't inline variadic functions with multret arguments
+        CHECK_EQ(
+        "\n" + compileFunction(
+                   R"(
+local function foo(...)
+    return 42
+end
+
+function bar(...)
+    local x = foo(...)
+    return x
+end
+)",
+                   1,
+                   2
+               ),
+        R"(
+GETUPVAL R0 0
+GETVARARGS R1 -1
+CALL R0 -1 1
+RETURN R0 1
 )"
     );
 


### PR DESCRIPTION
Instead of blanket-disabling inlining for vararg functions, with these changes inlining is evaluated at each call-site instead. Inlining can now succeed if the number of arguments passed to the function is known at compile-time (fixedret). I ran the Unit and Conformance tests and found no issues. For reasons beyond me, the Benchmark just showed "FAILURE" for every test, but these changes shouldn't have any significant regressions.

Additionally, I replaced the vararg inlining failure test with 2 new tests, which validate the two possible code paths for these changes.

Implements: https://github.com/luau-lang/luau/issues/1696