### PR TITLE
Actually perfect forwarding

### DIFF
--- a/Analysis/include/Luau/TypedAllocator.h
+++ b/Analysis/include/Luau/TypedAllocator.h
@@ -49,7 +49,7 @@ public:
 
         T* block = stuff.back();
         T* res = block + currentBlockSize;
-        new (res) T(std::forward<Args&&...>(args...));
+        new (res) T(std::forward<Args>(args)...);
         ++currentBlockSize;
         return res;
     }


### PR DESCRIPTION
The original wasn't actually allowing universal references and if you have a datatype with a deleted copy constructor, the template substitution would fail here. This lets me use `TypedAllocator` for some type that isn't copyable.