### PR TITLE
Set API definition if compile language is C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,9 +172,9 @@ if(LUAU_EXTERN_C)
     # enable extern "C" for VM (lua.h, lualib.h) and Compiler (luacode.h) to make Luau friendlier to use from non-C++ languages
     # note that we enable LUA_USE_LONGJMP=1 as well; otherwise functions like luaL_error will throw C++ exceptions, which can't be done from extern "C" functions
     target_compile_definitions(Luau.VM PUBLIC LUA_USE_LONGJMP=1)
-    target_compile_definitions(Luau.VM PUBLIC LUA_API=extern\"C\")
-    target_compile_definitions(Luau.Compiler PUBLIC LUACODE_API=extern\"C\")
-    target_compile_definitions(Luau.CodeGen PUBLIC LUACODEGEN_API=extern\"C\")
+    target_compile_definitions(Luau.VM PUBLIC $<$<COMPILE_LANGUAGE:CXX>:LUA_API=extern\"C\">)
+    target_compile_definitions(Luau.Compiler PUBLIC $<$<COMPILE_LANGUAGE:CXX>:LUACODE_API=extern\"C\">)
+    target_compile_definitions(Luau.CodeGen PUBLIC $<$<COMPILE_LANGUAGE:CXX>:LUACODEGEN_API=extern\"C\">)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER_EQUAL 1924)


### PR DESCRIPTION
same as #933 but using generator expression which can be used since the project upgraded to 3.10.

This seems to work flawlessly but there are likely some edge cases I did not consider, similar to #933.

Without this PR there are a lot of errors due to `extern "C"`not being valid in C:
```
luau-src/VM/include/lua.h:109:1: note: in expansion of macro ‘LUA_API’
  109 | LUA_API lua_State* lua_newstate(lua_Alloc f, void* ud);
      | ^~~~~~~
```

https://github.com/Jan200101/luau-c-test test repo that prints the `_VERSION` value in C and C++, the luau repo is commented out in the CMakeLists.txt but can be re-enabled to see the error that would happen without this PR.