### PR TITLE
Allow visibility configuration for internal APIs

### DIFF
--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -53,7 +53,7 @@
 #define LUALIB_API LUA_API
 
 // Can be used to reconfigure visibility for internal APIs
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(LUAU_PUBLIC_LUAI)
 #define LUAI_FUNC __attribute__((visibility("hidden"))) extern
 #define LUAI_DATA LUAI_FUNC
 #else


### PR DESCRIPTION
Allow configuring LUAI symbol visibility. When embedding, CodeGen depends on VM APIs; with default hidden visibility, linking fails. While this build method isn’t officially supported by Luau, it’s a useful nice-to-have for embedders. This change enables opting into public LUAI exports without affecting default behavior. Fixes RadiusDay/SwiftLuau#10.