### PR TITLE
perf(compiler): optimize vector arithmetic and numeric loop type inference

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -1862,8 +1862,8 @@ struct Compiler
                 }
                 else if (options.optimizationLevel >= 2 && (expr->op == AstExprBinary::Add || expr->op == AstExprBinary::Mul))
                 {
-                    // Optimization: replace k*r with r*k when r is known to be a number (otherwise metamethods may be called)
-                    if (LuauBytecodeType* ty = exprTypes.find(expr); ty && *ty == LBC_TYPE_NUMBER)
+                    // Optimization: replace k*r with r*k when r is known to be a number or vector (otherwise metamethods may be called)
+                    if (LuauBytecodeType* ty = exprTypes.find(expr); ty && (*ty == LBC_TYPE_NUMBER || *ty == LBC_TYPE_VECTOR))
                     {
                         int32_t lc = getConstantNumber(expr->left);
 
@@ -1873,7 +1873,7 @@ struct Compiler
 
                             bytecode.emitABC(getBinaryOpArith(expr->op, /* k= */ true), target, rr, uint8_t(lc));
 
-                            hintTemporaryExprRegType(expr->right, rr, LBC_TYPE_NUMBER, /* instLength */ 1);
+                            hintTemporaryExprRegType(expr->right, rr, *ty, /* instLength */ 1);
                             return;
                         }
                     }

--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -448,6 +448,19 @@ struct TypeMapVisitor : AstVisitor
         return false;
     }
 
+    bool visit(AstStatFor* node) override
+    {
+        resolvedLocals[node->var] = &builtinTypes.numberType;
+
+        node->from->visit(this);
+        node->to->visit(this);
+        if (node->step)
+            node->step->visit(this);
+        node->body->visit(this);
+
+        return false;
+    }
+
     bool visit(AstExprIndexExpr* node) override
     {
         node->expr->visit(this);

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -3846,7 +3846,7 @@ R0: vector [argument]
 R1: mat3 [argument]
 R2: userdata [argument]
 U0: number
-R6: any from 1 to 9
+R6: number from 1 to 9
 R3: vector from 0 to 30
 MUL R3 R0 R0
 LOADN R6 1
@@ -4756,7 +4756,7 @@ TEST_CASE("JumpTrampoline")
     CHECK_EQ("\n" + head, R"(
 local 0: reg 3, start pc 8 line 3, end pc 54545 line 20002
 local 1: reg 0, start pc 2 line 2, end pc 54549 line 20004
-R3: any from 2 to 54546
+R3: number from 2 to 54546
 R0: number from 1 to 54550
 LOADN R0 0
 LOADN R3 1

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -496,17 +496,17 @@ bb_bytecode_1:
   %22 = FLOAT_TO_VEC 4
   %23 = DIV_VEC %20, %22
   %32 = ADD_VEC %15, %23
-  %43 = FLOAT_TO_VEC 0.5
-  %44 = LOAD_TVALUE R2, 0i, tvector
-  %45 = MUL_VEC %43, %44
-  %54 = ADD_VEC %32, %45
-  %60 = FLOAT_TO_VEC 40
-  %61 = LOAD_TVALUE R3, 0i, tvector
-  %62 = DIV_VEC %60, %61
-  %71 = ADD_VEC %54, %62
-  %72 = TAG_VECTOR %71
-  STORE_TVALUE R4, %72
-  INTERRUPT 8u
+  %37 = LOAD_TVALUE R2, 0i, tvector
+  %39 = FLOAT_TO_VEC 0.5
+  %40 = MUL_VEC %37, %39
+  %49 = ADD_VEC %32, %40
+  %55 = FLOAT_TO_VEC 40
+  %56 = LOAD_TVALUE R3, 0i, tvector
+  %57 = DIV_VEC %55, %56
+  %66 = ADD_VEC %49, %57
+  %67 = TAG_VECTOR %66
+  STORE_TVALUE R4, %67
+  INTERRUPT 7u
   RETURN R4, 1i
 )"
     );
@@ -6995,16 +6995,16 @@ bb_bytecode_1:
   STORE_POINTER R2, %7
   STORE_TAG R2, ttable
   CHECK_GC
-  %19 = FLOAT_TO_VEC 2
-  %20 = LOAD_TVALUE R0, 0i, tvector
-  %21 = MUL_VEC %19, %20
-  %29 = LOAD_TVALUE R1, 0i, tvector
-  %30 = ADD_VEC %21, %29
-  %31 = TAG_VECTOR %30
-  STORE_TVALUE R3, %31
-  STORE_TVALUE R4, %31
-  SETLIST 8u, R2, R3, 2i, 1u, 2u
-  INTERRUPT 10u
+  %13 = LOAD_TVALUE R0, 0i, tvector
+  %15 = FLOAT_TO_VEC 2
+  %16 = MUL_VEC %13, %15
+  %24 = LOAD_TVALUE R1, 0i, tvector
+  %25 = ADD_VEC %16, %24
+  %26 = TAG_VECTOR %25
+  STORE_TVALUE R3, %26
+  STORE_TVALUE R4, %26
+  SETLIST 6u, R2, R3, 2i, 1u, 2u
+  INTERRUPT 8u
   RETURN R2, 1i
 )"
     );


### PR DESCRIPTION
 This PR improves the compiler's ability to optimize arithmetic expressions, specifically targeting vector operations and numeric `for` loops. By improving type inference, we can now apply better optimizations in more places.

Closes #2235