### PR TITLE
MSVC disable C4324 locally in lstate.h

### DIFF
--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -213,7 +213,16 @@ typedef struct global_State
 
     lua_ExecutionCallbacks ecb;
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4324)
+#endif
+
     alignas(16) uint8_t ecbdata[LUA_EXECUTION_CALLBACK_STORAGE];
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
     size_t memcatbytes[LUA_MEMORY_CATEGORIES]; // total amount of memory used by each memory category
 


### PR DESCRIPTION
Noticed in my personal game engine.

Caused by commit 93c83a4 / release 705

Env is VS2022 or VS2026.

I prefer /W4 /WX with a couple of noisy warnings disabled, however this warning is good to keep around. So I prefer fix at the header rather than disabling at CMakeLists or my downstream project.


Building Luau itself with /W4 /WX was not my configuration, so it is only this header causing a problem. 

However these are the warnings necessary to disable:
`cmake -G "Visual Studio 18 2026" -S . -B build -DCMAKE_CXX_FLAGS="/W4 /WX /wd4100 /wd4324 /wd4456 /wd4244 /wd4389 /wd4457 /wd4310 /wd4530 /wd4458 /wd4459 /wd4267 /wd4702 /wd4701 /wd4703 /wd4189 /DDOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS=1"`

Remove `/wd4324` from that list to get the error.

Depending on compile order you may get it elsewhere unrelated:
```
F:\luau\Common\include\Luau\Variant.h(205,1): warning C4324: 'Luau::Variant<std::string,double>': structure was padded due to alignment specifier [F:\luau\build\Luau.Config.vcxproj]
  (compiling source file '../Config/src/LuauConfig.cpp')
      F:\luau\Common\include\Luau\Variant.h(205,1):
      the template instantiation context (the oldest one first) is
          F:\luau\Config\include\Luau\LuauConfig.h(18,32):
          see reference to class template instantiation 'Luau::Variant<std::string,double>' being compiled
```

It is emitted in any instance `lstate.h` is included, so this invalidates opportunity to disable it for a TU since it is not a TU.

Is this fix preferable in upstream as it is? Thanks