### PR TITLE
Fix JsonEmitter sign-extension and improve RFC 8259 compliance

### DIFF
--- a/Analysis/src/AstJsonEncoder.cpp
+++ b/Analysis/src/AstJsonEncoder.cpp
@@ -133,19 +133,24 @@ struct AstJsonEncoder : public AstVisitor
 
     void writeString(std::string_view sv)
     {
-        // TODO escape more accurately?
         writeRaw("\"");
 
         for (char c : sv)
         {
-            if (c == '"')
+            unsigned char uc = static_cast<unsigned char>(c);
+
+            if (uc == '"')
                 writeRaw("\\\"");
-            else if (c == '\\')
+            else if (uc == '\\')
                 writeRaw("\\\\");
-            else if (c < ' ')
-                writeRaw(format("\\u%04x", c));
-            else if (c == '\n')
+            else if (uc == '\n') // New lines
                 writeRaw("\\n");
+            else if (uc == '\r') // Carriage returns
+                writeRaw("\\r");
+            else if (uc == '\t') // Tabs
+                writeRaw("\\t");
+            else if (uc < 32 || uc > 126)
+                writeRaw(format("\\u%04x", (int)uc)); 
             else
                 writeRaw(c);
         }

--- a/Analysis/src/JsonEmitter.cpp
+++ b/Analysis/src/JsonEmitter.cpp
@@ -155,14 +155,20 @@ void write(JsonEmitter& emitter, std::string_view sv)
 
     for (char c : sv)
     {
-        if (c == '"')
+        unsigned char uc = static_cast<unsigned char>(c);
+
+        if (uc == '"')
             emitter.writeRaw("\\\"");
-        else if (c == '\\')
+        else if (uc == '\\')
             emitter.writeRaw("\\\\");
-        else if (c == '\n')
-            emitter.writeRaw("\\n");
-        else if (c < ' ')
-            emitter.writeRaw(format("\\u%04x", c));
+        else if (uc == '\n')
+            emitter.writeRaw("\\n"); // New lines
+        else if (uc == '\r')
+            emitter.writeRaw("\\r"); // Carriage returns
+        else if (uc == '\t')
+            emitter.writeRaw("\\t"); // Tabs
+        else if (uc < 32 || uc > 126)
+            emitter.writeRaw(format("\\u%04x", (int)uc));
         else
             emitter.writeRaw(c);
     }


### PR DESCRIPTION
This PR addresses a bug where characters with the high bit set (values 128–255) were being incorrectly encoded as 32-bit sign-extended values (e.g., \uffffffbe instead of \u00be). It also improves the JSON output by ensuring all control characters (\r, \n, \t) and extended ASCII characters are properly escaped (char < 32 or char > 126).

Changes:
**Sign Extension Fix**: Cast char to unsigned char before integer promotion in the string writer.
This prevents the compiler from treating high byte characters as negative numbers, which was causing the "ffffff" 8-digit hex output.

**Explicit Escapes**: Added explicit handling for carriage returns (\r) and tabs (\t) to ensure the resulting JSON is strictly compliant with the RFC 8259 specification (https://datatracker.ietf.org/doc/html/rfc8259#section-7).