### PR TITLE
Improve the `os.time` type definition

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -226,7 +226,7 @@ type DateTypeResult = {
 }
 
 declare os: {
-    time: (time: DateTypeArg?) -> number,
+    time: ((time: DateTypeArg?) -> number?) & (() -> number),
     date: ((formatString: "*t" | "!*t", time: number?) -> DateTypeResult) & ((formatString: string?, time: number?) -> string),
     difftime: (t2: DateTypeResult | number, t1: DateTypeResult | number) -> number,
     clock: () -> number,

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -226,7 +226,7 @@ type DateTypeResult = {
 }
 
 declare os: {
-    time: ((time: DateTypeArg?) -> number?) & (() -> number),
+    time: ((time: DateTypeArg) -> number?) & (() -> number),
     date: ((formatString: "*t" | "!*t", time: number?) -> DateTypeResult) & ((formatString: string?, time: number?) -> string),
     difftime: (t2: DateTypeResult | number, t1: DateTypeResult | number) -> number,
     clock: () -> number,

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -491,8 +491,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "os_time_takes_optional_date_table")
 
     LUAU_REQUIRE_NO_ERRORS(result);
     CHECK("number" == toString(requireType("n1")));
-    CHECK("number" == toString(requireType("n2")));
-    CHECK("number" == toString(requireType("n3")));
+    CHECK("number?" == toString(requireType("n2")));
+    CHECK("number?" == toString(requireType("n3")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "thread_is_a_type")


### PR DESCRIPTION
`os.time` can return nil if you pass an out-of-range `DateTimeArg`:
```lua
> os.time({year=9, day=12, month=12})
nil
```

Modified the definition to reflect that