### PR TITLE
Implement FASTCALL for `table.create` and `table.clear`

### DIFF
--- a/CodeGen/src/BytecodeAnalysis.cpp
+++ b/CodeGen/src/BytecodeAnalysis.cpp
@@ -526,6 +526,14 @@ static void applyBuiltinCall(LuauBuiltinFunction bfid, BytecodeTypes& types)
         types.result = LBC_TYPE_NIL;
         types.a = LBC_TYPE_TABLE;
         break;
+    case LBF_TABLE_CREATE:
+        types.result = LBC_TYPE_TABLE;
+        types.a = LBC_TYPE_NUMBER;
+        break;
+    case LBF_TABLE_CLEAR:
+        types.result = LBC_TYPE_NIL;
+        types.a = LBC_TYPE_TABLE;
+        break;
     case LBF_RAWSET:
         types.result = LBC_TYPE_ANY;
         types.a = LBC_TYPE_TABLE;

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -1982,15 +1982,11 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
             if (tag == LUA_TBOOLEAN &&
                 (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Int)))
                 canSplitTvalueStore = true;
-            else if (
-                tag == LUA_TNUMBER &&
-                (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Double))
-            )
+            else if (tag == LUA_TNUMBER &&
+                     (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Double)))
                 canSplitTvalueStore = true;
-            else if (
-                tag == LUA_TINTEGER &&
-                (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Int64))
-            )
+            else if (tag == LUA_TINTEGER &&
+                     (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Int64)))
                 canSplitTvalueStore = true;
             else if (tag != 0xff && isGCO(tag) && value.kind == IrOpKind::Inst)
                 canSplitTvalueStore = true;

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -1500,6 +1500,12 @@ static void handleBuiltinEffects(ConstPropState& state, LuauBuiltinFunction bfid
     case LBF_TABLE_INSERT:
         state.invalidateHeap();
         return; // table.insert does not modify result registers.
+    case LBF_TABLE_CLEAR:
+        state.invalidateHeap();
+        return; // table.clear does not modify result registers.
+    case LBF_TABLE_CREATE:
+        state.invalidateHeap();
+        break;
     case LBF_RAWSET:
         state.invalidateHeap();
         break;
@@ -1976,11 +1982,15 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
             if (tag == LUA_TBOOLEAN &&
                 (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Int)))
                 canSplitTvalueStore = true;
-            else if (tag == LUA_TNUMBER &&
-                     (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Double)))
+            else if (
+                tag == LUA_TNUMBER &&
+                (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Double))
+            )
                 canSplitTvalueStore = true;
-            else if (tag == LUA_TINTEGER &&
-                     (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Int64)))
+            else if (
+                tag == LUA_TINTEGER &&
+                (value.kind == IrOpKind::Inst || (value.kind == IrOpKind::Constant && function.constOp(value).kind == IrConstKind::Int64))
+            )
                 canSplitTvalueStore = true;
             else if (tag != 0xff && isGCO(tag) && value.kind == IrOpKind::Inst)
                 canSplitTvalueStore = true;

--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -705,6 +705,8 @@ enum LuauBuiltinFunction
     // buffer.readinteger / buffer.writeinteger (int64_t)
     LBF_BUFFER_READINTEGER,
     LBF_BUFFER_WRITEINTEGER,
+    LBF_TABLE_CREATE,
+    LBF_TABLE_CLEAR,
 };
 
 // Capture type, used in LOP_CAPTURE

--- a/Compiler/src/Builtins.cpp
+++ b/Compiler/src/Builtins.cpp
@@ -225,6 +225,10 @@ static int getBuiltinFunctionId(const Builtin& builtin, const CompileOptions& op
             return LBF_TABLE_INSERT;
         if (builtin.method == "unpack")
             return LBF_TABLE_UNPACK;
+        if (builtin.method == "create")
+            return LBF_TABLE_CREATE;
+        if (builtin.method == "clear")
+            return LBF_TABLE_CLEAR;
     }
 
     if (builtin.object == "buffer")
@@ -603,6 +607,12 @@ BuiltinInfo getBuiltinInfo(int bfid)
 
     case LBF_TABLE_UNPACK:
         return {-1, -1}; // 1, 2 or 3 parameters
+
+    case LBF_TABLE_CREATE:
+        return {-1, 1}; // 1 or 2 parameters
+
+    case LBF_TABLE_CLEAR:
+        return {1, 0};
 
     case LBF_VECTOR:
         return {-1, 1}; // 3 or 4 parameters in some configurations

--- a/Compiler/src/Builtins.cpp
+++ b/Compiler/src/Builtins.cpp
@@ -9,6 +9,7 @@
 
 LUAU_FASTFLAGVARIABLE(LuauIntegerFastcalls)
 LUAU_FASTFLAGVARIABLE(LuauIntegerBufferFastcalls)
+LUAU_FASTFLAGVARIABLE(LuauCompileTableBuiltinsCreateClear)
 
 namespace Luau
 {
@@ -225,9 +226,9 @@ static int getBuiltinFunctionId(const Builtin& builtin, const CompileOptions& op
             return LBF_TABLE_INSERT;
         if (builtin.method == "unpack")
             return LBF_TABLE_UNPACK;
-        if (builtin.method == "create")
+        if (FFlag::LuauCompileTableBuiltinsCreateClear && builtin.method == "create")
             return LBF_TABLE_CREATE;
-        if (builtin.method == "clear")
+        if (FFlag::LuauCompileTableBuiltinsCreateClear && builtin.method == "clear")
             return LBF_TABLE_CLEAR;
     }
 

--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -767,6 +767,8 @@ struct TypeMapVisitor : AstVisitor
             case LBF_RAWGET:
             case LBF_TABLE_INSERT:
             case LBF_TABLE_UNPACK:
+            case LBF_TABLE_CREATE:
+            case LBF_TABLE_CLEAR:
             case LBF_SELECT_VARARG:
             case LBF_GETMETATABLE:
             case LBF_SETMETATABLE:

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -2563,6 +2563,52 @@ static bool luau_hassse41()
 }
 #endif
 
+static int luauF_tablecreate(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double n = nvalue(arg0);
+        int size;
+        luai_num2int(size, n);
+
+        if (size >= 0 && size <= 1000000)
+        {
+            if (luaC_needsGC(L))
+                return -1;
+
+            LuaTable* t = luaH_new(L, size, 0);
+
+            if (nparams >= 2)
+            {
+                TValue* v = args;
+                for (int i = 0; i < size; ++i)
+                    setobj2t(L, &t->array[i], v);
+            }
+
+            sethvalue(L, res, t);
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_tableclear(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 0 && ttistable(arg0))
+    {
+        LuaTable* t = hvalue(arg0);
+
+        if (t->readonly)
+            return -1;
+
+        luaH_clear(t);
+        return 0;
+    }
+
+    return -1;
+}
+
 const luau_FastFunction luauF_table[256] = {
     NULL,
     luauF_assert,
@@ -2738,6 +2784,9 @@ const luau_FastFunction luauF_table[256] = {
 
     luauF_bufferreadlong,
     luauF_bufferwritelong,
+
+    luauF_tablecreate,
+    luauF_tableclear,
 
 // When adding builtins, add them above this line; what follows is 64 "dummy" entries with luauF_missing fallback.
 // This is important so that older versions of the runtime that don't support newer builtins automatically fall back via luauF_missing.

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -36,6 +36,7 @@ LUAU_FASTFLAG(LuauCompileNewMathConstantsFolded)
 LUAU_FASTFLAG(LuauCompileStringInterpTargetTop)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(LuauCompileTypeAliases)
+LUAU_FASTFLAG(LuauCompileTableBuiltinsCreateClear)
 
 using namespace Luau;
 
@@ -10790,6 +10791,56 @@ GETIMPORT R4 3 [math.random]
 CALL R4 0 -1
 CALL R1 -1 1
 RETURN R1 1
+)"
+    );
+}
+
+TEST_CASE("TableFastcall")
+{
+    ScopedFastFlag luauTableBuiltins{FFlag::LuauCompileTableBuiltinsCreateClear, true};
+
+    // table.create with 1 arg
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+return table.create(42)
+)"),
+        R"(
+LOADN R1 42
+FASTCALL1 133 R1 L0
+GETIMPORT R0 2 [table.create]
+CALL R0 1 -1
+L0: RETURN R0 -1
+)"
+    );
+
+    // table.create with 2 args
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+return table.create(10, 0)
+)"),
+        R"(
+LOADN R1 10
+FASTCALL2K 133 R1 K0 L0 [0]
+LOADK R2 K0 [0]
+GETIMPORT R0 3 [table.create]
+CALL R0 2 -1
+L0: RETURN R0 -1
+)"
+    );
+
+    // table.clear with 1 arg
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+local t = {}
+table.clear(t)
+)"),
+        R"(
+NEWTABLE R0 0 0
+FASTCALL1 134 R0 L0
+MOVE R2 R0
+GETIMPORT R1 2 [table.clear]
+CALL R1 1 0
+L0: RETURN R0 0
 )"
     );
 }


### PR DESCRIPTION
This PR adds `FASTCALL` support for `table.create` and `table.clear` to avoid the overhead of standard `GETIMPORT` and `CALL` sequences.

As requested by @tommyscholly, I've checked the numbers using both `bench.py` and a hot loop. I ran some hot-loop micro-benchmarks to isolate the overhead, and the interpreter showed table.clear running about 49% faster and table.create about 14% faster. Native mode also gets a nice bump, with table.clear speeding up by 55% and table.create by 22%. Running the standard bench.py suite just gives noise since tests like tictactoe and chess don't spam these functions in their hot loops, but the micro-benchmarks give a better picture of the actual overhead reduction.

<details>
<summary>Bytecode difference</summary>

Code:
```lua
local t = table.create(10)
table.clear(t)
return t
```

**Before:**
```
Function 0 (??):
    1: local t = table.create(10)
GETIMPORT R0 2 [table.create]
LOADN R1 10
CALL R0 1 1
    2: table.clear(t)
GETIMPORT R1 4 [table.clear]
MOVE R2 R0
CALL R1 1 0
    3: return t
RETURN R0 1
```

**After:**
```
Function 0 (??):
REMARK builtin table.create/1
    1: local t = table.create(10)
LOADN R1 10
FASTCALL1 133 R1 L0
GETIMPORT R0 2 [table.create]
CALL R0 1 1
REMARK builtin table.clear/1
    2: table.clear(t)
L0: FASTCALL1 134 R0 L1
MOVE R2 R0
GETIMPORT R1 4 [table.clear]
CALL R1 1 0
    3: return t
L1: RETURN R0 1
```
</details>

I've updated the compiler and VM handlers, and added the necessary heap invalidation in `OptimizeConstProp.cpp` to keep native optimizations correct.

Fixes #2360