### PR TITLE
Move FFlagLuauIntegerType definition

### DIFF
--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -19,7 +19,7 @@ LUAU_FASTINTVARIABLE(LuauParseErrorLimit, 100)
 // See docs/SyntaxChanges.md for an explanation.
 LUAU_FASTFLAGVARIABLE(LuauSolverV2)
 LUAU_DYNAMIC_FASTFLAGVARIABLE(DebugLuauReportReturnTypeVariadicWithTypeSuffix, false)
-LUAU_FASTFLAGVARIABLE(LuauIntegerType)
+LUAU_FASTFLAG(LuauIntegerType)
 LUAU_FASTFLAGVARIABLE(DesugaredArrayTypeReferenceIsEmpty)
 LUAU_FASTFLAGVARIABLE(LuauConst2)
 LUAU_FASTFLAGVARIABLE(DebugLuauNoInline)

--- a/Common/src/SharedFlags.cpp
+++ b/Common/src/SharedFlags.cpp
@@ -1,0 +1,8 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Common.h"
+
+// Define fast flags here that will be used across various Luau targets such as
+// VM and Ast - by putting the flag definition here, you prevent dependent projects
+// from breaking when they statically bind to VM but not Ast for example.
+
+LUAU_FASTFLAGVARIABLE(LuauIntegerType)

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -15,6 +15,7 @@ target_sources(Luau.Common PRIVATE
     Common/include/Luau/VecDeque.h
 
     Common/src/BytecodeWire.cpp
+    Common/src/SharedFlags.cpp
     Common/src/StringUtils.cpp
     Common/src/TimeTrace.cpp
 )


### PR DESCRIPTION
Move definition of FFlag::LuauIntegerType to SharedFlags.cpp in Luau.Common so that dependent projects on Luau.VM which do not depend on Luau.Ast can still build.

Fixes https://github.com/luau-lang/luau/issues/2368