### PR TITLE
Allow iterating over tables without an explicit indexer

### DIFF
--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -26,6 +26,7 @@
 #include "Luau/TypeUtils.h"
 #include "Luau/TypeOrPack.h"
 #include "Luau/VisitType.h"
+#include "Luau/BuiltinTypeFunctions.h"
 
 #include <algorithm>
 #include <sstream>
@@ -43,6 +44,7 @@ LUAU_FASTFLAGVARIABLE(LuauComparisonToNilsIsAlwaysOk2)
 LUAU_FASTFLAGVARIABLE(LuauLValueCompoundAssignmentVisitLhs)
 LUAU_FASTFLAG(LuauExternReadWriteAttributes)
 LUAU_FASTFLAG(LuauThreadUniferStateThroughTypeFunctionReduction)
+LUAU_FASTFLAGVARIABLE(LuauIteratingTablesWithoutIndexers)
 
 namespace Luau
 {
@@ -1077,14 +1079,49 @@ void TypeChecker2::visit(AstStatForIn* forInStatement)
     }
     else if (const TableType* ttv = get<TableType>(iteratorTy))
     {
-        if ((forInStatement->vars.size == 1 || forInStatement->vars.size == 2) && ttv->indexer)
+        if (FFlag::LuauIteratingTablesWithoutIndexers)
         {
-            testIsSubtype(variableTypes[0], ttv->indexer->indexType, forInStatement->vars.data[0]->location);
-            if (variableTypes.size() == 2)
-                testIsSubtype(variableTypes[1], ttv->indexer->indexResultType, forInStatement->vars.data[1]->location);
+            TypeId indexType;
+            TypeId indexResultType;
+            bool hasIndexer = false;
+
+            if (ttv->indexer)
+            {
+                indexType = ttv->indexer->indexType;
+                indexResultType = ttv->indexer->indexResultType;
+                hasIndexer = true;
+            }
+            else
+            {
+                if (ttv->props.size() > 0)
+                {
+                    TypeId clone = arena.addType(iteratorTy->clone());
+                    indexType = arena.addTypeFunction(builtinTypes->typeFunctions->keyofFunc, {clone}, {});
+                    indexResultType = arena.addTypeFunction(builtinTypes->typeFunctions->indexFunc, {clone, indexType}, {});
+                    hasIndexer = true;
+                }
+            }
+
+            if ((forInStatement->vars.size == 1 || forInStatement->vars.size == 2) && hasIndexer)
+            {
+                testIsSubtype(variableTypes[0], indexType, forInStatement->vars.data[0]->location);
+                if (variableTypes.size() == 2)
+                    testIsSubtype(variableTypes[1], indexResultType, forInStatement->vars.data[1]->location);
+            }
+            else
+                reportError(GenericError{"Cannot iterate over a table without indexer"}, forInStatement->values.data[0]->location);
         }
         else
-            reportError(GenericError{"Cannot iterate over a table without indexer"}, forInStatement->values.data[0]->location);
+        {
+            if ((forInStatement->vars.size == 1 || forInStatement->vars.size == 2) && ttv->indexer)
+            {
+                testIsSubtype(variableTypes[0], ttv->indexer->indexType, forInStatement->vars.data[0]->location);
+                if (variableTypes.size() == 2)
+                    testIsSubtype(variableTypes[1], ttv->indexer->indexResultType, forInStatement->vars.data[1]->location);
+            }
+            else
+                reportError(GenericError{"Cannot iterate over a table without indexer"}, forInStatement->values.data[0]->location);
+        }
     }
     else if (get<AnyType>(iteratorTy) || get<ErrorType>(iteratorTy) || get<NeverType>(iteratorTy))
     {

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -32,7 +32,7 @@ LUAU_FASTFLAG(LuauLValueCompoundAssignmentVisitLhs)
 LUAU_FASTFLAG(LuauUnifier2HandleMismatchedPacks2)
 LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
 LUAU_FASTFLAG(LuauOverloadGetsInstantiated2)
-
+LUAU_FASTFLAG(LuauIteratingTablesWithoutIndexers)
 
 TEST_SUITE_BEGIN("TableTests");
 
@@ -6743,5 +6743,28 @@ TEST_CASE_FIXTURE(Fixture, "compound_assignment_writes_lhs")
     REQUIRE(get<PropertyAccessViolation>(result.errors[0]));
 }
 
+TEST_CASE_FIXTURE(Fixture, "iterate_table_without_indexer")
+{
+    ScopedFastFlag sff{FFlag::LuauIteratingTablesWithoutIndexers, true};
+
+    CheckResult result = check(R"(
+        local t = {
+            hello = true,
+            bye = false
+        }
+
+        for k, v in t do
+            local x: "hello" | "bye" = k
+            local y: true | false = v
+        end
+
+        for k, v: string in t do
+        end
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    REQUIRE(result.errors[0].location.begin.line == 11);
+    LUAU_REQUIRE_ERROR(result, TypeMismatch);
+}
 
 TEST_SUITE_END();


### PR DESCRIPTION
Allows:

```luau
local t = {
    hello = true,
    bye = false
}

for k, v in t do -- No type error
    local x: "hello" | "bye" = k
    local y: true | false = v
end

for k, v: string in t do -- Type error on `v`
end
```

Adds 1 test

Flagged behind `LuauIteratingTablesWithoutIndexers`