### PR TITLE
Add missing <algorithm> include in OptimizeDeadStore.cpp

### DIFF
--- a/CodeGen/src/OptimizeDeadStore.cpp
+++ b/CodeGen/src/OptimizeDeadStore.cpp
@@ -5,6 +5,7 @@
 #include "Luau/IrVisitUseDef.h"
 #include "Luau/IrUtils.h"
 
+#include <algorithm>
 #include <array>
 
 #include "lobject.h"


### PR DESCRIPTION
# Summary
CodeGen/src/OptimizeDeadStore.cpp uses `std::find_if` in `generateVmExitBlocks` but does not include `<algorithm>`. This breaks compilation on toolchains that do not expose `std::find_if` through transitive includes.

# Details
The regression appears in the 0.721 sync. The file now contains two `std::find_if` uses, but only includes `<array>` among the relevant STL headers. Adding the direct header dependency fixes the build in a standards-compliant way and avoids relying on implementation-specific include leakage.

---

Fixes #2395 