### PR TITLE
Preserve module names for overload detail errors

### DIFF
--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -1524,7 +1524,7 @@ void TypeChecker2::visit(AstExprVarargs* expr)
     // TODO!
 }
 
-static void reportAvailableOverloads(ErrorVec& errors, Location location, const std::vector<TypeId>& overloads)
+static void reportAvailableOverloads(ErrorVec& errors, Location location, const ModuleName& moduleName, const std::vector<TypeId>& overloads)
 {
     if (overloads.empty())
         return;
@@ -1543,7 +1543,7 @@ static void reportAvailableOverloads(ErrorVec& errors, Location location, const 
         s << toString(overloads[i]);
     }
 
-    errors.emplace_back(location, ExtraInformation{s.str()});
+    errors.emplace_back(location, moduleName, ExtraInformation{s.str()});
 }
 
 void TypeChecker2::visitCall(AstExprCall* call)
@@ -1766,7 +1766,7 @@ void TypeChecker2::visitCall(AstExprCall* call)
         if (!overloadsToReport.empty())
         {
             reportError(MultipleNonviableOverloads{argHead.size()}, call->location);
-            reportAvailableOverloads(module->errors, call->location, overloadsToReport);
+            reportAvailableOverloads(module->errors, call->location, module->name, overloadsToReport);
         }
 
         return;
@@ -1795,7 +1795,7 @@ void TypeChecker2::visitCall(AstExprCall* call)
         std::stringstream ss;
         ss << "No overload for function accepts " << argHead.size() << " arguments.";
         reportError(GenericError{ss.str()}, call->func->location);
-        reportAvailableOverloads(module->errors, call->func->location, result2.arityMismatches);
+        reportAvailableOverloads(module->errors, call->func->location, module->name, result2.arityMismatches);
         return;
     }
 

--- a/tests/TypeInfer.tryUnify.test.cpp
+++ b/tests/TypeInfer.tryUnify.test.cpp
@@ -289,6 +289,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cli_41095_concat_log_in_sealed_table_unifica
 
     LUAU_REQUIRE_ERROR_COUNT(2, result);
     CHECK_EQ(toString(result.errors[0]), "No overload for function accepts 0 arguments.");
+    CHECK_EQ(result.errors[1].moduleName, "MainModule");
     if (!FFlag::DebugLuauForceOldSolver)
         CHECK_EQ(toString(result.errors[1]), "Available overloads: <V>({V}, V) -> (); and <V>({V}, number, V) -> ()");
     else


### PR DESCRIPTION
The new solver's "Available overloads" follow-up diagnostic gets emitted without a module name, so downstream consumers see it as coming from an empty path which breaks paths.

See primary error looking correct but follow ups rendering as junk relative paths:
```text
Packages/_Index/example_package/src/init.luau:1845.6-1845.85: TypeError: None of the overloads for function that accept 1 arguments are compatible.
../../../../..:1845.6-1845.85: TypeError: Available overloads: <V>({V}, V) -> (); and <V>({V}, number, V) -> ()
```

After fix:
```text
Packages/_Index/example_package/src/init.luau:1845.6-1845.85: TypeError: None of the overloads for function that accept 1 arguments are compatible.
Packages/_Index/example_package/src/init.luau:1845.6-1845.85: TypeError: Available overloads: <V>({V}, V) -> (); and <V>({V}, number, V) -> ()
```
