### PR TITLE
include algorithm to OptimizeDeadStore.cpp

### DIFF
--- a/CodeGen/src/OptimizeDeadStore.cpp
+++ b/CodeGen/src/OptimizeDeadStore.cpp
@@ -5,6 +5,7 @@
 #include "Luau/IrVisitUseDef.h"
 #include "Luau/IrUtils.h"
 
+#include <algorithm>
 #include <array>
 
 #include "lobject.h"


### PR DESCRIPTION
I met compiation error on gcc 16.

```
/usr/bin/c++  -ICodeGen/include -IVM/include -ICommon/include -IVM/src -fPIC -g -Wall -Wimplicit-fallthrough -Wsign-compare -Wno-unused -Wno-maybe-uninitialized -MD -MT CMakeFiles/Luau.CodeGen.dir/CodeGen/src/OptimizeDeadStore.cpp.o -MF CMakeFiles/Luau.CodeGen.dir/CodeGen/src/OptimizeDeadStore.cpp.o.d -o CMakeFiles/Luau.CodeGen.dir/CodeGen/src/OptimizeDeadStore.cpp.o -c CodeGen/src/OptimizeDeadStore.cpp
CodeGen/src/OptimizeDeadStore.cpp: In lambda function:
CodeGen/src/OptimizeDeadStore.cpp:1494:36: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
 1494 |                 if (auto it = std::find_if(
      |                                    ^~~~~~~
      |                                    find
CodeGen/src/OptimizeDeadStore.cpp: In lambda function:
CodeGen/src/OptimizeDeadStore.cpp:1555:31: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
 1555 |                 else if (std::find_if(
      |                               ^~~~~~~
      |                               find
```

OptimizeDeadStore.cpp uses `find_if`, but `<algorithm>` is not included, whereas it is included in OptimizeConstProp.cpp.

https://github.com/luau-lang/luau/blob/0.721/CodeGen/src/OptimizeDeadStore.cpp#L1494
https://github.com/luau-lang/luau/blob/0.721/CodeGen/src/OptimizeConstProp.cpp#L16

This PR try to fix it.
