### PR TITLE
Fix nilable source overload selection

### DIFF
--- a/Analysis/src/OverloadResolver.cpp
+++ b/Analysis/src/OverloadResolver.cpp
@@ -14,6 +14,8 @@
 
 #include <algorithm>
 
+LUAU_FASTFLAGVARIABLE(LuauPreferExactArityOverOptionalOverload)
+
 namespace Luau
 {
 
@@ -243,7 +245,8 @@ OverloadResolution OverloadResolver::resolveOverload(
     else
         testFunctionOrUnion(result, ty, argsPack, fnLocation, uniqueTypes);
 
-    preferOverloadsThatDoNotNeedOmittedOptionalArguments(result, argsPack);
+    if (FFlag::LuauPreferExactArityOverOptionalOverload)
+        preferOverloadsThatDoNotNeedOmittedOptionalArguments(result, argsPack);
 
     return result;
 }

--- a/Analysis/src/OverloadResolver.cpp
+++ b/Analysis/src/OverloadResolver.cpp
@@ -12,6 +12,8 @@
 #include "Luau/TypeUtils.h"
 #include "Luau/Unifier2.h"
 
+#include <algorithm>
+
 namespace Luau
 {
 
@@ -172,6 +174,55 @@ static bool areUnsatisfiedArgumentsOptional(const SubtypingReasonings& reasoning
     return true;
 }
 
+static bool needsOmittedOptionalArguments(TypePackId argPack, TypeId overload)
+{
+    const FunctionType* ftv = get<FunctionType>(follow(overload));
+    if (!ftv)
+        return false;
+
+    const auto [argHead, argTail] = flatten(argPack);
+    if (argTail)
+        return false;
+
+    const auto [funArgHead, _funArgTail] = flatten(ftv->argTypes);
+    return argHead.size() < funArgHead.size();
+}
+
+static void preferOverloadsThatDoNotNeedOmittedOptionalArguments(OverloadResolution& result, TypePackId argPack)
+{
+    const bool hasPreferredOverload =
+        std::any_of(result.ok.begin(), result.ok.end(), [argPack](TypeId overload) {
+            return !needsOmittedOptionalArguments(argPack, overload);
+        }) ||
+        std::any_of(result.potentialOverloads.begin(), result.potentialOverloads.end(), [argPack](const auto& overload) {
+            return !needsOmittedOptionalArguments(argPack, overload.first);
+        });
+
+    if (!hasPreferredOverload)
+        return;
+
+    result.ok.erase(
+        std::remove_if(
+            result.ok.begin(),
+            result.ok.end(),
+            [argPack](TypeId overload) {
+                return needsOmittedOptionalArguments(argPack, overload);
+            }
+        ),
+        result.ok.end()
+    );
+    result.potentialOverloads.erase(
+        std::remove_if(
+            result.potentialOverloads.begin(),
+            result.potentialOverloads.end(),
+            [argPack](const auto& overload) {
+                return needsOmittedOptionalArguments(argPack, overload.first);
+            }
+        ),
+        result.potentialOverloads.end()
+    );
+}
+
 OverloadResolution OverloadResolver::resolveOverload(
     TypeId ty,
     TypePackId argsPack,
@@ -191,6 +242,8 @@ OverloadResolution OverloadResolver::resolveOverload(
     }
     else
         testFunctionOrUnion(result, ty, argsPack, fnLocation, uniqueTypes);
+
+    preferOverloadsThatDoNotNeedOmittedOptionalArguments(result, argsPack);
 
     return result;
 }

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -32,6 +32,7 @@ LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
 LUAU_FASTFLAG(LuauKeepExplicitMapForGlobalTypes2)
 LUAU_FASTFLAG(LuauBidirectionalInferenceBetterUnionHandling)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
+LUAU_FASTFLAG(LuauPreferExactArityOverOptionalOverload)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -3443,6 +3444,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_ambiguous_call")
 TEST_CASE_FIXTURE(Fixture, "overload_selection_prefers_exact_arity_over_omitted_optional_arguments")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag preferExactArity{FFlag::LuauPreferExactArityOverOptionalOverload, true};
 
     auto result = check(R"(
         type Source<T> = (() -> T) & ((T) -> T)
@@ -3463,6 +3465,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_prefers_exact_arity_over_omitted_
 TEST_CASE_FIXTURE(Fixture, "overload_selection_prefers_shorter_overload_when_longer_one_only_matches_via_optional_argument")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag preferExactArity{FFlag::LuauPreferExactArityOverOptionalOverload, true};
 
     auto result = check(R"(
         local f: ((number) -> "one") & ((number, string?) -> "two") = nil :: any

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -3440,6 +3440,41 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_ambiguous_call")
     CHECK_EQ("*error-type*", toString(requireType("g")));
 }
 
+TEST_CASE_FIXTURE(Fixture, "overload_selection_prefers_exact_arity_over_omitted_optional_arguments")
+{
+    ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+
+    auto result = check(R"(
+        type Source<T> = (() -> T) & ((T) -> T)
+
+        local text = (nil :: any) :: Source<string?>
+
+        local a = text()
+        local b = text("hi")
+        local c = text(nil)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("string?", toString(requireType("a")));
+    CHECK_EQ("string?", toString(requireType("b")));
+    CHECK_EQ("string?", toString(requireType("c")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "overload_selection_prefers_shorter_overload_when_longer_one_only_matches_via_optional_argument")
+{
+    ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+
+    auto result = check(R"(
+        local f: ((number) -> "one") & ((number, string?) -> "two") = nil :: any
+        local x = f(1)
+        local y = f(1, "s")
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("\"one\"", toString(requireType("x")));
+    CHECK_EQ("\"two\"", toString(requireType("y")));
+}
+
 TEST_CASE_FIXTURE(Fixture, "overload_selection_pick_better_arity")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};


### PR DESCRIPTION
The Vide library uses the following API:
```luau
type Source<T> = (() -> T) & ((T) -> T)

local text = (nil :: any) :: Source<string?>

text("hi")
text() -- currently ambiguous in the new solver
text(nil)
```

Under the new solver, this results in an error:
```
TypeError: Calling function (() -> string?) & ((string?) -> string?) with argument pack () is ambiguous.
```

The solver does not differentiate between `()` and `(nil)`. 

I'm uninformed as to what semantics Luau wants long-term for nilable parameters vs ommited args during overload resolution, the above example may not be a bug. 
I think it'd certainly be useful if resolution could prefer the overload matching the number of args provided.

Fixes https://github.com/luau-lang/luau/issues/2362

