### PR TITLE
Fix AutoComplete providing incomplete results

### DIFF
--- a/Analysis/src/AutocompleteCore.cpp
+++ b/Analysis/src/AutocompleteCore.cpp
@@ -452,7 +452,7 @@ static void autocompleteProps(
     {
         autocompleteProps(module, typeArena, builtinTypes, rootTy, mt->table, indexType, nodes, result, seen);
 
-        if (auto mtable = get<TableType>(follow(mt->metatable)))
+        if (auto mtable = getTableType(follow(mt->metatable)))
             fillMetatableProps(mtable);
     }
     else if (auto i = get<IntersectionType>(ty))

--- a/Analysis/src/AutocompleteCore.cpp
+++ b/Analysis/src/AutocompleteCore.cpp
@@ -29,6 +29,7 @@ LUAU_FASTFLAGVARIABLE(DebugLuauMagicVariableNames)
 LUAU_FASTFLAGVARIABLE(LuauAutocompleteStringSingletonIntersection)
 LUAU_FASTFLAGVARIABLE(LuauAutocompleteConst)
 LUAU_FASTFLAGVARIABLE(LuauAutocompleteExport)
+LUAU_FASTFLAGVARIABLE(LuauAutocompleteMetatableInheritance)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 
 static constexpr std::array<std::string_view, 12> kStatementStartingKeywords_DEPRECATED =
@@ -452,7 +453,9 @@ static void autocompleteProps(
     {
         autocompleteProps(module, typeArena, builtinTypes, rootTy, mt->table, indexType, nodes, result, seen);
 
-        if (auto mtable = getTableType(follow(mt->metatable)))
+        const TableType* mtable =
+            FFlag::LuauAutocompleteMetatableInheritance ? getTableType(follow(mt->metatable)) : get<TableType>(follow(mt->metatable));
+        if (mtable)
             fillMetatableProps(mtable);
     }
     else if (auto i = get<IntersectionType>(ty))

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -21,6 +21,7 @@ LUAU_FASTFLAG(LuauTraceTypesInNonstrictMode2)
 LUAU_FASTFLAG(LuauSetMetatableDoesNotTimeTravel)
 LUAU_FASTINT(LuauTypeInferRecursionLimit)
 LUAU_FASTFLAG(LuauAutocompleteStringSingletonIntersection)
+LUAU_FASTFLAG(LuauAutocompleteMetatableInheritance)
 
 using namespace Luau;
 
@@ -5202,6 +5203,21 @@ x.@1
 
     auto ac = autocomplete('1');
     CHECK(ac.entryMap.empty());
+}
+
+TEST_CASE_FIXTURE(ACBuiltinsFixture, "autocomplete_props_through_metatable_typed_metatable")
+{
+    ScopedFastFlag sff{FFlag::LuauAutocompleteMetatableInheritance, true};
+
+    check(R"(
+        local Base = { baseProp = 5 }
+        local Meta = setmetatable({ __index = Base }, {})
+        local obj = setmetatable({}, Meta)
+        obj.@1
+    )");
+
+    auto ac = autocomplete('1');
+    CHECK(ac.entryMap.count("baseProp"));
 }
 
 TEST_CASE_FIXTURE(ACBuiltinsFixture, "autocomplete_table_insert")

--- a/tests/FragmentAutocomplete.test.cpp
+++ b/tests/FragmentAutocomplete.test.cpp
@@ -25,6 +25,7 @@ LUAU_FASTINT(LuauParseErrorLimit)
 LUAU_FASTFLAG(LuauBetterReverseDependencyTracking)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauAutocompleteStringSingletonIntersection)
+LUAU_FASTFLAG(LuauAutocompleteMetatableInheritance)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 
@@ -1603,6 +1604,34 @@ tbl.
     CHECK_EQ(1, fragment.result->acResults.entryMap.size());
     CHECK(fragment.result->acResults.entryMap.count("abc"));
     CHECK_EQ(AutocompleteContext::Property, fragment.result->acResults.context);
+}
+
+TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "autocomplete_props_through_metatable_typed_metatable")
+{
+    ScopedFastFlag sff{FFlag::LuauAutocompleteMetatableInheritance, true};
+
+    const std::string source = R"(
+local Base = { baseProp = 5 }
+local Meta = setmetatable({ __index = Base }, {})
+local obj = setmetatable({}, Meta)
+)";
+    const std::string updated = R"(
+local Base = { baseProp = 5 }
+local Meta = setmetatable({ __index = Base }, {})
+local obj = setmetatable({}, Meta)
+obj. @1
+)";
+
+    autocompleteFragmentInNewSolver(
+        source,
+        updated,
+        '1',
+        [](FragmentAutocompleteStatusResult& fragment)
+        {
+            REQUIRE(fragment.result);
+            CHECK(fragment.result->acResults.entryMap.count("baseProp"));
+        }
+    );
 }
 
 TEST_CASE_FIXTURE(FragmentAutocompleteBuiltinsFixture, "typecheck_fragment_handles_unusable_module")


### PR DESCRIPTION
Member autocomplete misses properties for multi level metatable inheritance when the metatable is itself represented as a `MetatableType`.  (ie: `Derived = setmetatable({}, { __index = Base })`)

The type checker already resolves these properties, but autocomplete only looked through plain table metatables.