### PR TITLE
Preserve bracketed attribute syntax in the CST

### DIFF
--- a/Ast/include/Luau/Cst.h
+++ b/Ast/include/Luau/Cst.h
@@ -234,6 +234,28 @@ public:
     CstTypeInstantiation instantiation;
 };
 
+class CstAttribute : public CstNode
+{
+public:
+    LUAU_CST_RTTI(CstAttribute)
+
+    CstAttribute(
+        Position openBracketPosition,
+        Position namePosition,
+        Position argsOpenParens,
+        AstArray<Position> argsCommaPositions,
+        Position argsCloseParens
+    );
+
+    Position openBracketPosition; // '@[', only on the first attribute of the list
+    Position namePosition;
+    Position argsOpenParens; // '(', only if the arguments are parenthesized
+    AstArray<Position> argsCommaPositions;
+    Position argsCloseParens;                            // ')', only if the arguments are parenthesized
+    Position separatorPosition = Position::missing();    // ',', may be missing for last attribute
+    Position closeBracketPosition = Position::missing(); // ']', only on the last attribute of the list
+};
+
 class CstStatDo : public CstNode
 {
 public:

--- a/Ast/src/Cst.cpp
+++ b/Ast/src/Cst.cpp
@@ -3,6 +3,7 @@
 #include "Luau/Cst.h"
 #include "Luau/Common.h"
 
+LUAU_FASTFLAG(LuauCstAttribute)
 LUAU_FASTFLAG(LuauCstExprGroup)
 LUAU_FASTFLAG(LuauCstTypeGroup)
 
@@ -96,6 +97,23 @@ CstExprExplicitTypeInstantiation::CstExprExplicitTypeInstantiation(CstTypeInstan
     : CstNode(CstClassIndex())
     , instantiation(instantiation)
 {
+}
+
+CstAttribute::CstAttribute(
+    Position openBracketPosition,
+    Position namePosition,
+    Position argsOpenParens,
+    AstArray<Position> argsCommaPositions,
+    Position argsCloseParens
+)
+    : CstNode(CstClassIndex())
+    , openBracketPosition(openBracketPosition)
+    , namePosition(namePosition)
+    , argsOpenParens(argsOpenParens)
+    , argsCommaPositions(argsCommaPositions)
+    , argsCloseParens(argsCloseParens)
+{
+    LUAU_ASSERT(FFlag::LuauCstAttribute);
 }
 
 CstStatDo::CstStatDo(Position statsStartPosition, Position endPosition)

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAGVARIABLE(DebugLuauNoInline)
 LUAU_FASTFLAGVARIABLE(LuauConstJustReportErrorForUnderfill)
 LUAU_FASTFLAGVARIABLE(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAGVARIABLE(LuauAllowGlobalDeclarationToBeCalledClass)
+LUAU_FASTFLAGVARIABLE(LuauCstAttribute)
 LUAU_FASTFLAGVARIABLE(LuauCstExprGroup)
 LUAU_FASTFLAGVARIABLE(LuauCstTypeGroup)
 LUAU_FASTFLAGVARIABLE(LuauTableEntriesDontNeedToMatchIndent)
@@ -1015,6 +1016,9 @@ void Parser::parseAttribute(TempVector<AstAttr*>& attributes)
 
         if (lexer.current().type != ']')
         {
+            bool isFirstAttribute = true;
+            CstAttribute* previousCstNode = nullptr;
+
             while (true)
             {
                 Name name = parseName("attribute name");
@@ -1022,11 +1026,25 @@ void Parser::parseAttribute(TempVector<AstAttr*>& attributes)
                 Location nameLoc = name.location;
                 const char* attrName = name.name.value;
 
+                AstAttr* attribute = nullptr;
+
+                Position argsOpenParens = Position::missing();
+                TempVector<Position> argsCommaPositions(scratchPosition);
+                Position argsCloseParens = Position::missing();
+
                 if (lexer.current().type == Lexeme::RawString || lexer.current().type == Lexeme::QuotedString || lexer.current().type == '{' ||
                     lexer.current().type == '(')
                 {
+                    const bool parensForm = lexer.current().type == '(';
 
-                    auto [args, argsLocation, _exprLocation] = parseCallList(nullptr);
+                    auto [args, argsLocation, exprLocation] =
+                        parseCallList(FFlag::LuauCstAttribute && options.storeCstData ? &argsCommaPositions : nullptr);
+
+                    if (FFlag::LuauCstAttribute && options.storeCstData && parensForm)
+                    {
+                        argsOpenParens = exprLocation.begin;
+                        argsCloseParens = exprLocation.end;
+                    }
 
                     for (const AstExpr* arg : args)
                     {
@@ -1036,18 +1054,45 @@ void Parser::parseAttribute(TempVector<AstAttr*>& attributes)
 
                     std::optional<AstAttr::Type> type = validateAttribute(nameLoc, attrName, attributes, args);
 
-                    attributes.push_back(
-                        allocator.alloc<AstAttr>(Location(nameLoc, argsLocation), type.value_or(AstAttr::Type::Unknown), args, AstName(attrName))
-                    );
+                    Location attributeLocation = Location(nameLoc, argsLocation);
+                    if (FFlag::LuauCstAttribute && isFirstAttribute)
+                        attributeLocation = Location(open.location.begin, attributeLocation.end);
+
+                    attribute = allocator.alloc<AstAttr>(attributeLocation, type.value_or(AstAttr::Type::Unknown), args, AstName(attrName));
                 }
                 else
                 {
                     std::optional<AstAttr::Type> type = validateAttribute(nameLoc, attrName, attributes, empty);
-                    attributes.push_back(allocator.alloc<AstAttr>(nameLoc, type.value_or(AstAttr::Type::Unknown), empty, AstName(attrName)));
+
+                    Location attributeLocation = nameLoc;
+                    if (FFlag::LuauCstAttribute && isFirstAttribute)
+                        attributeLocation = Location(open.location.begin, attributeLocation.end);
+
+                    attribute = allocator.alloc<AstAttr>(attributeLocation, type.value_or(AstAttr::Type::Unknown), empty, AstName(attrName));
                 }
+
+                attributes.push_back(attribute);
+
+                if (FFlag::LuauCstAttribute && options.storeCstData)
+                {
+                    CstAttribute* cstNode = allocator.alloc<CstAttribute>(
+                        isFirstAttribute ? open.location.begin : Position::missing(),
+                        nameLoc.begin,
+                        argsOpenParens,
+                        copy(argsCommaPositions),
+                        argsCloseParens
+                    );
+                    cstNodeMap[attribute] = cstNode;
+                    previousCstNode = cstNode;
+                }
+
+                isFirstAttribute = false;
 
                 if (lexer.current().type == ',')
                 {
+                    if (previousCstNode)
+                        previousCstNode->separatorPosition = lexer.current().location.begin;
+
                     nextLexeme();
                 }
                 else
@@ -1055,6 +1100,9 @@ void Parser::parseAttribute(TempVector<AstAttr*>& attributes)
                     break;
                 }
             }
+
+            if (previousCstNode && lexer.current().type == ']')
+                previousCstNode->closeBracketPosition = lexer.current().location.begin;
         }
         else
         {

--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -15,6 +15,7 @@ LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(LuauConst2)
 
 LUAU_FASTFLAGVARIABLE(LuauErrorTolerantPrettyPrinting)
+LUAU_FASTFLAG(LuauCstAttribute)
 LUAU_FASTFLAG(LuauCstExprGroup)
 LUAU_FASTFLAG(LuauCstTypeGroup)
 
@@ -1600,9 +1601,51 @@ struct Printer
 
     void visualizeAttribute(AstAttr& attribute)
     {
-        advance(attribute.location.begin);
-        writer.symbol("@");
-        writer.identifier(attribute.name.value);
+        if (FFlag::LuauCstAttribute)
+        {
+            if (const auto cstNode = lookupCstNode<CstAttribute>(&attribute))
+            {
+                maybeAdvanceAndWrite(cstNode->openBracketPosition, "@[");
+
+                advance(cstNode->namePosition);
+                writer.identifier(attribute.name.value);
+
+                if (cstNode->argsOpenParens.hasValue())
+                {
+                    advance(cstNode->argsOpenParens);
+                    writer.symbol("(");
+
+                    CommaSeparatorInserter comma(writer, cstNode->argsCommaPositions.begin());
+                    for (const auto& arg : attribute.args)
+                    {
+                        comma();
+                        visualize(*arg);
+                    }
+
+                    maybeAdvanceAndWrite(cstNode->argsCloseParens, ")");
+                }
+                else
+                {
+                    for (const auto& arg : attribute.args)
+                        visualize(*arg);
+                }
+
+                maybeAdvanceAndWrite(cstNode->separatorPosition, ",");
+                maybeAdvanceAndWrite(cstNode->closeBracketPosition, "]");
+            }
+            else
+            {
+                advance(attribute.location.begin);
+                writer.symbol("@");
+                writer.identifier(attribute.name.value);
+            }
+        }
+        else
+        {
+            advance(attribute.location.begin);
+            writer.symbol("@");
+            writer.identifier(attribute.name.value);
+        }
     }
 
     void visualizeTypeAnnotation(AstType& typeAnnotation)

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -23,6 +23,7 @@ LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
+LUAU_FASTFLAG(LuauCstAttribute)
 LUAU_FASTFLAG(LuauCstExprGroup)
 LUAU_FASTFLAG(LuauCstTypeGroup)
 
@@ -3863,6 +3864,59 @@ TEST_CASE_FIXTURE(Fixture, "type_group_with_cst")
     CHECK_EQ(cstNode->closePosition, Position{1, 24});
 }
 
+TEST_CASE_FIXTURE(Fixture, "bracketed_attributes_with_cst")
+{
+    ScopedFastFlag _{FFlag::LuauCstAttribute, true};
+
+    ParseOptions parseOptions;
+    parseOptions.storeCstData = true;
+
+    ParseResult result = parseEx("@[checked, native()] local function f() end", parseOptions);
+    REQUIRE(result.root);
+
+    REQUIRE_EQ(result.root->body.size, 1);
+    auto localFunction = result.root->body.data[0]->as<AstStatLocalFunction>();
+    REQUIRE(localFunction);
+    REQUIRE_EQ(localFunction->func->attributes.size, 2);
+
+    CHECK_EQ(localFunction->location.begin, Position{0, 0});
+
+    AstAttr* checkedAttribute = localFunction->func->attributes.data[0];
+    CHECK_EQ(checkedAttribute->location.begin, Position{0, 0});
+
+    const auto baseCheckedCstNode = result.cstNodeMap.find(checkedAttribute);
+    REQUIRE(baseCheckedCstNode);
+    const auto checkedCstNode = (*baseCheckedCstNode)->as<CstAttribute>();
+    REQUIRE(checkedCstNode);
+    CHECK_EQ(checkedCstNode->openBracketPosition, Position{0, 0});
+    CHECK_EQ(checkedCstNode->namePosition, Position{0, 2});
+    CHECK_EQ(checkedCstNode->separatorPosition, Position{0, 9});
+    CHECK(!checkedCstNode->closeBracketPosition.hasValue());
+    CHECK(!checkedCstNode->argsOpenParens.hasValue());
+
+    AstAttr* nativeAttribute = localFunction->func->attributes.data[1];
+
+    const auto baseNativeCstNode = result.cstNodeMap.find(nativeAttribute);
+    REQUIRE(baseNativeCstNode);
+    const auto nativeCstNode = (*baseNativeCstNode)->as<CstAttribute>();
+    REQUIRE(nativeCstNode);
+    CHECK(!nativeCstNode->openBracketPosition.hasValue());
+    CHECK_EQ(nativeCstNode->namePosition, Position{0, 11});
+    CHECK_EQ(nativeCstNode->argsOpenParens, Position{0, 17});
+    CHECK_EQ(nativeCstNode->argsCommaPositions.size, 0);
+    CHECK_EQ(nativeCstNode->argsCloseParens, Position{0, 18});
+    CHECK(!nativeCstNode->separatorPosition.hasValue());
+    CHECK_EQ(nativeCstNode->closeBracketPosition, Position{0, 19});
+
+    result = parseEx("@native local function g() end", parseOptions);
+    REQUIRE(result.root);
+    REQUIRE_EQ(result.root->body.size, 1);
+    localFunction = result.root->body.data[0]->as<AstStatLocalFunction>();
+    REQUIRE(localFunction);
+    REQUIRE_EQ(localFunction->func->attributes.size, 1);
+    CHECK(!result.cstNodeMap.find(localFunction->func->attributes.data[0]));
+}
+
 TEST_SUITE_END();
 
 TEST_SUITE_BEGIN("ParseErrorRecovery");
@@ -4797,7 +4851,8 @@ end)");
 
     CHECK_EQ(attributes.size, 1);
 
-    checkAttribute(attributes.data[0], AstAttr::Type::Deprecated, Location(Position(1, 2), Position(1, 70)));
+    Location location = FFlag::LuauCstAttribute ? Location(Position(1, 0), Position(1, 70)) : Location(Position(1, 2), Position(1, 70));
+    checkAttribute(attributes.data[0], AstAttr::Type::Deprecated, location);
 }
 
 TEST_CASE_FIXTURE(Fixture, "non_literal_attribute_arguments_is_not_allowed")

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -14,6 +14,7 @@ LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauErrorTolerantPrettyPrinting)
+LUAU_FASTFLAG(LuauCstAttribute)
 LUAU_FASTFLAG(LuauCstExprGroup)
 LUAU_FASTFLAG(LuauCstTypeGroup)
 LUAU_FASTFLAG(LuauTableEntriesDontNeedToMatchIndent)
@@ -2220,6 +2221,132 @@ TEST_CASE("prettyPrint_function_attributes")
         local function t() end
         )";
         CHECK_EQ(code, prettyPrint(code, {}, true).code);
+    }
+}
+
+TEST_CASE("prettyPrint_bracketed_function_attributes")
+{
+    ScopedFastFlag _{FFlag::LuauCstAttribute, true};
+
+    std::string code = R"(
+        @[native]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[native()]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[checked, native]
+        local function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[ checked , native ]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[deprecated { use = "bar", reason = "legacy" }]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        local foo = @[native] function() end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @native @[checked]
+        function foo:bar()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[
+            deprecated {
+                use = "bar",
+            },
+            native
+        ]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[ native()]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[ native   (  )       ]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[native,checked]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    code = R"(
+        @[native] @[checked]
+        function foo()
+        end
+    )";
+    CHECK_EQ(code, prettyPrint(code, {}, true).code);
+
+    {
+        ScopedFastFlag errorTolerant{FFlag::LuauErrorTolerantPrettyPrinting, true};
+
+        // invalid attribute arguments are parse errors, but still roundtrip
+        code = R"(
+            @[deprecated("a", "b")]
+            function foo()
+            end
+        )";
+        CHECK_EQ(code, prettyPrint(code, {}, true, true).code);
+
+        code = R"(
+            @[deprecated "Very deprecated"]
+            function foo()
+            end
+        )";
+        CHECK_EQ(code, prettyPrint(code, {}, true, true).code);
+
+        code = R"(
+            @[deprecated(
+                "a",
+                "b"
+            )]
+            function foo()
+            end
+        )";
+        CHECK_EQ(code, prettyPrint(code, {}, true, true).code);
+
+        // should not crash
+        prettyPrint("@[] function foo() end", {}, true, true);
+        prettyPrint("@[", {}, true, true);
+        prettyPrint("@[native", {}, true, true);
     }
 }
 


### PR DESCRIPTION
Bracketed attribute lists were not recorded in the CST: `parseAttribute`
consumed `@[`, `,` and `]` without storing their positions, and the
pretty printer always reprinted attributes in the bare `@name` form.
As a result `@[native]` reprinted as `  @native`, `@[native()]` lost
its parentheses, and `@[deprecated { use = "x" }]` dropped its
arguments entirely, so reprinted sources no longer matched (or even
meant) what was parsed.

Behind FFlag::LuauCstAttribute:

- add CstAttribute, storing the positions of `@[`, the attribute name,
  the argument parentheses and their commas, the `,` separating
  attributes within a list, and the closing `]`
- store a CstAttribute node for every attribute of a bracketed list
  when ParseOptions::storeCstData is set
- start the first attribute of a bracketed list at `@[`, so statements
  and function expressions deriving their start location from the
  attribute list cover the full source range
- reprint bracketed attribute lists (inculding their arguments) from
  the CST data in the pretty printer

Bare attributes (`@native`) are unaffected and still roundtrip without
a CST node

Fixes #2436 