### PR TITLE
Preserve negative zero in math.round on SSE4.1

### DIFF
--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -2538,7 +2538,7 @@ LUAU_TARGET_SSE41 static int luauF_round_sse41(lua_State* L, StkId res, TValue* 
         // roundsd only supports bankers rounding natively, so we need to emulate rounding by using truncation
         // offset is prevfloat(0.5), which is important so that we round prevfloat(0.5) to 0.
         const double offset = 0.49999999999999994;
-        setnvalue(res, roundsd_sse41<_MM_FROUND_TO_ZERO>(a1 + (a1 < 0 ? -offset : offset)));
+        setnvalue(res, roundsd_sse41<_MM_FROUND_TO_ZERO>(a1 + (signbit(a1) ? -offset : offset)));
         return 1;
     }
 

--- a/tests/conformance/math.luau
+++ b/tests/conformance/math.luau
@@ -354,6 +354,10 @@ assert(math.round(-3.5) == -4)
 assert(math.round(math.huge) == math.huge)
 assert(math.round(0.49999999999999994) == 0)
 assert(math.round(-0.49999999999999994) == 0)
+-- a zero result keeps the sign of the input; noinline stops the call from being constant folded so the runtime path is exercised
+assert(1 / math.round(noinline(-0.0)) == -math.huge)
+assert(1 / math.round(noinline(-0.4)) == -math.huge)
+assert(1 / math.round(noinline(0.0)) == math.huge)
 
 assert(math.round(noinline(0)) == 0)
 assert(math.round(noinline(0.4)) == 0)


### PR DESCRIPTION
The SSE4.1 fast path used `a1 < 0`, which is false for `-0.0`, so it returned `+0.0`
This now checks the sign bit instead

Test coverage was added for `math.round(-0.0)`