### PR TITLE
Honor riscv targets before host x64 detection

### DIFF
--- a/CodeGen/include/Luau/CodeGenCommon.h
+++ b/CodeGen/include/Luau/CodeGenCommon.h
@@ -11,7 +11,9 @@
 #define CODEGEN_ASSERT(expr) (void)sizeof(!!(expr))
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__riscv)
+// RISC-V currently has no native code generation backend.
+#elif defined(__x86_64__) || defined(_M_X64)
 #define CODEGEN_TARGET_X64
 #elif defined(__aarch64__) || defined(_M_ARM64)
 #define CODEGEN_TARGET_A64

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -22,7 +22,9 @@
 
 // Some functions like floor/ceil have SSE4.1 equivalents but we currently support systems without SSE4.1
 // Note that we only need to do this when SSE4.1 support is not guaranteed by compiler settings, as otherwise compiler will optimize these for us.
-#if (defined(__x86_64__) || defined(_M_X64)) && !defined(__SSE4_1__) && !defined(__AVX__)
+#if defined(__riscv)
+// RISC-V must not inherit host x64 SSE4.1 assumptions during cross-target builds.
+#elif (defined(__x86_64__) || defined(_M_X64)) && !defined(__SSE4_1__) && !defined(__AVX__)
 #if defined(_MSC_VER) && !defined(__clang__)
 #define LUAU_TARGET_SSE41
 #elif defined(__GNUC__) && defined(__has_attribute)


### PR DESCRIPTION

## Why

Luau's CodeGen and VM headers infer target architecture directly from compiler predefined macros. In a simulated or cross-target `riscv64` configuration built from an `x86_64` host compiler, that logic can incorrectly inherit host `x64` code generation and SSE4.1 assumptions. This patch makes RISC-V take precedence so unsupported native-code paths are not selected by mistake.

## What changed

- Update `CodeGenCommon.h` so `__riscv` takes priority over host `x64` detection and does not define an `x64` or `A64` native CodeGen backend for RISC-V.
- Update `luaconf.h` so simulated or cross-target RISC-V builds do not inherit the host-only `LUAU_TARGET_SSE41` path.
- Keep the patch conservative: it does not add a RISC-V native CodeGen backend and continues to leave native CodeGen unsupported on RISC-V.

## Verification

- Ran native CMake configuration with Ninja using `LUAU_BUILD_CLI=OFF` and `LUAU_BUILD_TESTS=OFF`.
- Built the native tree successfully with `cmake --build build-codex-native --parallel 4`.
- Ran simulated `riscv64` CMake configuration with `CMAKE_SYSTEM_NAME=Linux`, `CMAKE_SYSTEM_PROCESSOR=riscv64`, `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`, and forced `__riscv=1` / `__riscv_xlen=64` because no real RISC-V toolchain is available on the host.
- Built the simulated `riscv64` tree successfully with `cmake --build build-codex-riscv --parallel 4`.
- Preprocessed `CodeGenCommon.h` under forced `__riscv=1` / `__riscv_xlen=64` and confirmed no `CODEGEN_TARGET_X64` or `CODEGEN_TARGET_A64` macro is defined.
- Preprocessed `luaconf.h` under forced `__riscv=1` / `__riscv_xlen=64` and confirmed `LUAU_TARGET_SSE41` is not defined.

## Notes

This is a conservative portability patch. It prevents simulated or cross-target `riscv64` builds from inheriting host `x64` native-code assumptions, but it does not implement a RISC-V native CodeGen backend. Verification covers native library build stability, simulated RISC-V library build success, and preprocessor checks for target macro selection.
