### PR TITLE
Compiler: Take `std::string_view` over `std::string`

### DIFF
--- a/Compiler/include/Luau/Compiler.h
+++ b/Compiler/include/Luau/Compiler.h
@@ -5,6 +5,7 @@
 #include "Luau/Location.h"
 #include "Luau/StringUtils.h"
 #include "Luau/Common.h"
+#include <string_view>
 
 namespace Luau
 {
@@ -90,11 +91,11 @@ private:
 
 // compiles bytecode into bytecode builder using either a pre-parsed AST or parsing it from source; throws on errors
 void compileOrThrow(BytecodeBuilder& bytecode, const ParseResult& parseResult, AstNameTable& names, const CompileOptions& options = {});
-void compileOrThrow(BytecodeBuilder& bytecode, const std::string& source, const CompileOptions& options = {}, const ParseOptions& parseOptions = {});
+void compileOrThrow(BytecodeBuilder& bytecode, std::string_view source, const CompileOptions& options = {}, const ParseOptions& parseOptions = {});
 
 // compiles bytecode into a bytecode blob, that either contains the valid bytecode or an encoded error that luau_load can decode
 std::string compile(
-    const std::string& source,
+    std::string_view source,
     const CompileOptions& options = {},
     const ParseOptions& parseOptions = {},
     BytecodeEncoder* encoder = nullptr

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -5205,11 +5205,11 @@ void compileOrThrow(BytecodeBuilder& bytecode, const ParseResult& parseResult, A
     bytecode.finalize();
 }
 
-void compileOrThrow(BytecodeBuilder& bytecode, const std::string& source, const CompileOptions& options, const ParseOptions& parseOptions)
+void compileOrThrow(BytecodeBuilder& bytecode, std::string_view source, const CompileOptions& options, const ParseOptions& parseOptions)
 {
     Allocator allocator;
     AstNameTable names(allocator);
-    ParseResult result = Parser::parse(source.c_str(), source.size(), names, allocator, parseOptions);
+    ParseResult result = Parser::parse(source.data(), source.size(), names, allocator, parseOptions);
 
     if (!result.errors.empty())
         throw ParseErrors(result.errors);
@@ -5217,13 +5217,13 @@ void compileOrThrow(BytecodeBuilder& bytecode, const std::string& source, const 
     compileOrThrow(bytecode, result, names, options);
 }
 
-std::string compile(const std::string& source, const CompileOptions& options, const ParseOptions& parseOptions, BytecodeEncoder* encoder)
+std::string compile(std::string_view source, const CompileOptions& options, const ParseOptions& parseOptions, BytecodeEncoder* encoder)
 {
     LUAU_TIMETRACE_SCOPE("compile", "Compiler");
 
     Allocator allocator;
     AstNameTable names(allocator);
-    ParseResult result = Parser::parse(source.c_str(), source.size(), names, allocator, parseOptions);
+    ParseResult result = Parser::parse(source.data(), source.size(), names, allocator, parseOptions);
 
     if (!result.errors.empty())
     {

--- a/Compiler/src/lcode.cpp
+++ b/Compiler/src/lcode.cpp
@@ -17,7 +17,7 @@ char* luau_compile(const char* source, size_t size, lua_CompileOptions* options,
         memcpy(static_cast<void*>(&opts), options, sizeof(opts));
     }
 
-    std::string result = compile(std::string(source, size), opts);
+    std::string result = compile(std::string_view(source, size), opts);
 
     char* copy = static_cast<char*>(malloc(result.size()));
     if (!copy)


### PR DESCRIPTION
`Luau::compile` and `Luau::compileOrThrow` took a `const std::string&`, but they never cared about it being a `std::string`. Since the library is compiled with C++ 17, this can take `std::string_view` to avoid callers needing to create a `std::string`.