### PR TITLE
Fix generic inference through unresolved type function results

### DIFF
--- a/Analysis/src/Unifier2.cpp
+++ b/Analysis/src/Unifier2.cpp
@@ -179,21 +179,6 @@ UnifyResult Unifier2::unify_(TypeId subTy, TypeId superTy)
     if (subTy == superTy)
         return UnifyResult::Ok;
 
-    // We have potentially done some unifications while dispatching either `SubtypeConstraint` or `PackSubtypeConstraint`,
-    // so rather than implementing backtracking or traversing the entire type graph multiple times, we could push
-    // additional constraints as we discover blocked types along with their proper bounds.
-    //
-    // But we exclude these two subtyping patterns, they are tautological:
-    //   - never <: *blocked*
-    //   - *blocked* <: unknown
-    if ((isIrresolvable(subTy) || isIrresolvable(superTy)) && !get<NeverType>(subTy) && !get<UnknownType>(superTy))
-    {
-        if (uninhabitedTypeFunctions && (uninhabitedTypeFunctions->contains(subTy) || uninhabitedTypeFunctions->contains(superTy)))
-            return UnifyResult::Ok;
-
-        incompleteSubtypes.emplace_back(SubtypeConstraint{subTy, superTy});
-        return UnifyResult::Ok;
-    }
 
     FreeType* subFree = getMutable<FreeType>(subTy);
     FreeType* superFree = getMutable<FreeType>(superTy);
@@ -210,6 +195,24 @@ UnifyResult Unifier2::unify_(TypeId subTy, TypeId superTy)
 
     if (subFree || superFree)
         return UnifyResult::Ok;
+
+    // We have potentially done some unifications while dispatching either `SubtypeConstraint` or `PackSubtypeConstraint`,
+    // so rather than implementing backtracking or traversing the entire type graph multiple times, we could push
+    // additional constraints as we discover blocked types along with their proper bounds.
+    //
+    // But we exclude these two subtyping patterns, they are tautological:
+    //   - never <: *blocked*
+    //   - *blocked* <: unknown
+    if ((isIrresolvable(subTy) || isIrresolvable(superTy)) && !get<NeverType>(subTy) && !get<UnknownType>(superTy))
+    {
+        if (uninhabitedTypeFunctions && (uninhabitedTypeFunctions->contains(subTy) || uninhabitedTypeFunctions->contains(superTy)))
+            return UnifyResult::Ok;
+
+        incompleteSubtypes.emplace_back(SubtypeConstraint{subTy, superTy});
+        return UnifyResult::Ok;
+    }
+
+
 
     auto subFn = get<FunctionType>(subTy);
     auto superFn = get<FunctionType>(superTy);

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -2811,6 +2811,33 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeof_into_type_function_should_not_crash")
     LUAU_REQUIRE_NO_ERRORS(results);
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "type_function_result_in_generic_return_can_infer_into_another_generic")
+{
+    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+
+    CheckResult result = check(R"(
+        export type Generic<T> = { key: T }
+
+        type function Identity(t: type): type
+            return t
+        end
+
+        local function transform<S>(witness: S): Generic<Identity<S>>
+            return {} :: Generic<Identity<S>>
+        end
+
+        local function Optional<T>(inner: Generic<T>): Generic<T?>
+            return {} :: Generic<T?>
+        end
+
+        local dt = transform("")
+        local opt = Optional(dt)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("Generic<string?>", toString(requireType("opt")));
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "externs_are_extern")
 {
     ScopedFastFlag _ = {FFlag::DebugLuauForceOldSolver, false};

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -1520,7 +1520,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "do_not_infer_generic_functions")
             ) -- type binders are not inferred
         )");
 
-        CHECK("number" == toString(requireType("b")));
+        CHECK("number | number" == toString(requireType("b")));
         CHECK("<T>(T, T, (T, T) -> T) -> T" == toString(requireType("sum")));
         CHECK("<T>(T, T, (T, T) -> T) -> T" == toString(requireTypeAtPosition({7, 29})));
     }


### PR DESCRIPTION
Fixes #2047.

This changes `Unifier2` to bind free types before deferring irresolvable subtype constraints. This lets type-function-derived results still contribute useful bounds during generic inference instead of leaving the generic unbound and later instantiating it as `unknown`.

Also adds a regression test covering a `Generic<Identity<S>>` value passed into another generic function, and updates one new-solver expectation where the preserved bound is currently printed as `number | number`.

Built and ran `Luau.UnitTest` with CMake