### PR TITLE
VM: Add functions to get/set inline destructors of userdata

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -47,6 +47,7 @@ typedef struct lua_State lua_State;
 
 typedef int (*lua_CFunction)(lua_State* L);
 typedef int (*lua_Continuation)(lua_State* L, int status);
+typedef void (*lua_InlineDestructor)(void* userdata);
 
 /*
 ** prototype for memory-allocation functions
@@ -175,6 +176,7 @@ LUA_API int lua_lightuserdatatag(lua_State* L, int idx);
 LUA_API lua_State* lua_tothread(lua_State* L, int idx);
 LUA_API void* lua_tobuffer(lua_State* L, int idx, size_t* len);
 LUA_API const void* lua_topointer(lua_State* L, int idx);
+LUA_API lua_InlineDestructor lua_toinlineuserdatadtor(lua_State* L, int idx);
 
 /*
 ** push functions (C -> stack)
@@ -200,7 +202,7 @@ LUA_API int lua_pushthread(lua_State* L);
 LUA_API void lua_pushlightuserdatatagged(lua_State* L, void* p, int tag);
 LUA_API void* lua_newuserdatatagged(lua_State* L, size_t sz, int tag);
 LUA_API void* lua_newuserdatataggedwithmetatable(lua_State* L, size_t sz, int tag); // metatable fetched with lua_getuserdatametatable
-LUA_API void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*));
+LUA_API void* lua_newuserdatadtor(lua_State* L, size_t sz, lua_InlineDestructor dtor);
 
 LUA_API void* lua_newbuffer(lua_State* L, size_t sz);
 
@@ -233,6 +235,7 @@ LUA_API void lua_rawseti(lua_State* L, int idx, int n);
 LUA_API void lua_rawsetptagged(lua_State* L, int idx, void* p, int tag);
 LUA_API int lua_setmetatable(lua_State* L, int objindex);
 LUA_API int lua_setfenv(lua_State* L, int idx);
+LUA_API void lua_setinlineuserdatadtor(lua_State* L, int idx, lua_InlineDestructor dtor);
 
 /*
 ** `load' and `call' functions (load and run Luau bytecode)

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -673,6 +673,18 @@ const void* lua_topointer(lua_State* L, int idx)
     }
 }
 
+lua_InlineDestructor lua_toinlineuserdatadtor(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    if (!ttisuserdata(o) || uvalue(o)->tag != UTAG_IDTOR)
+        return NULL;
+
+    Udata* u = uvalue(o);
+    lua_InlineDestructor dtor = nullptr;
+    memcpy(&dtor, &u->data + u->len - sizeof(dtor), sizeof(dtor));
+    return dtor;
+}
+
 /*
 ** push functions (C -> stack)
 */
@@ -1104,6 +1116,16 @@ int lua_setfenv(lua_State* L, int idx)
     return res;
 }
 
+void lua_setinlineuserdatadtor(lua_State* L, int idx, lua_InlineDestructor dtor)
+{
+    api_checknelems(L, 1);
+    StkId o = index2addr(L, idx);
+    api_checkvalidindex(L, o);
+    api_check(L, ttisuserdata(o) && uvalue(o)->tag == UTAG_IDTOR);
+    Udata* u = uvalue(o);
+    memcpy(&u->data + u->len - sizeof(dtor), &dtor, sizeof(dtor));
+}
+
 /*
 ** `load' and `call' functions (run Lua code)
 */
@@ -1504,7 +1526,7 @@ void* lua_newuserdatataggedwithmetatable(lua_State* L, size_t sz, int tag)
     return u->data;
 }
 
-void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*))
+void* lua_newuserdatadtor(lua_State* L, size_t sz, lua_InlineDestructor dtor)
 {
     api_check(L, dtor != nullptr);
     luaC_checkGC(L);

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1118,7 +1118,6 @@ int lua_setfenv(lua_State* L, int idx)
 
 void lua_setinlineuserdatadtor(lua_State* L, int idx, lua_InlineDestructor dtor)
 {
-    api_checknelems(L, 1);
     StkId o = index2addr(L, idx);
     api_checkvalidindex(L, o);
     api_check(L, ttisuserdata(o) && uvalue(o)->tag == UTAG_IDTOR);

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -3549,7 +3549,7 @@ TEST_CASE("UserdataApi")
     );
 
     *(int*)ud3 = 43;
-    *(char*)ud4 = 3;
+    *(char*)ud4 = 4;
 
     // user data with named metatable
     luaL_newmetatable(L, "udata1");
@@ -3583,6 +3583,24 @@ TEST_CASE("UserdataApi")
 
     CHECK(luaL_checkudata(L, -2, "udata3") == ud7);
     CHECK(luaL_checkudata(L, -1, "udata4") == ud8);
+
+    auto idtorAdd = +[](void* data)
+    {
+        dtorhits += *(int*)data;
+    };
+    auto idtorSub = +[](void* data)
+    {
+        dtorhits -= *(int*)data;
+    };
+    void* ud9 = lua_newuserdatadtor(L, sizeof(int), idtorAdd);
+    *(int*)ud9 = 1;
+    CHECK((lua_toinlineuserdatadtor(L, -1) == idtorAdd));
+    // Tag 51, not UTAG_IDTOR.
+    CHECK((lua_toinlineuserdatadtor(L, -2) == nullptr));
+    lua_setinlineuserdatadtor(L, -1, nullptr);
+    CHECK((lua_toinlineuserdatadtor(L, -1) == nullptr));
+    lua_setinlineuserdatadtor(L, -1, idtorSub);
+    CHECK((lua_toinlineuserdatadtor(L, -1) == idtorSub));
 
     globalState.reset();
 


### PR DESCRIPTION
This adds
```c
lua_InlineDestructor lua_toinlineuserdatadtor(lua_State* L, int idx);
void lua_setinlineuserdatadtor(lua_State* L, int idx, lua_InlineDestructor dtor);
```

They get/set the destructor for userdata with an inline destructor (`UTAG_IDTOR`). Setting the destructor after the userdata has been created is more important here. The use-case is fallible construction of the userdata:

```cpp
void *mem = lua_newuserdatadtor(L, sizeof(T), [](void*mem){
    std::destroy_at<T>(static_cast<T*>(mem));
});
T *udata = static_cast<T*>(mem);
// Try to construct T. If this fails (e.g. arguments can't be converted), we shouldn't
// invoke the destructor, so we should unset it.
```

I found this when trying to get the sol2 Lua bindings to work with Luau. There, [the userdata is constructed first](https://github.com/ThePhD/sol2/blob/c1f95a773c6f8f4fde8ca3efe872e7286afe4444/include/sol/call.hpp#L332) and [the arguments are matched later](https://github.com/ThePhD/sol2/blob/c1f95a773c6f8f4fde8ca3efe872e7286afe4444/include/sol/call.hpp#L338). In case of overloaded functions, there might not exist an overload, so we'd error out and drop the userdata. We can only set the destructor once we constructed the value inside the userdata.