### PR TITLE
Disable -Wmissing-field-initializers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ else()
     list(APPEND LUAU_OPTIONS -Wall) # All warnings
     list(APPEND LUAU_OPTIONS -Wimplicit-fallthrough)
     list(APPEND LUAU_OPTIONS -Wsign-compare) # This looks to be included in -Wall for GCC but not clang
+    list(APPEND LUAU_OPTIONS -Wno-missing-field-initializers) # Intentional in struct initializers across the codebase
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ LUAU_CONFORMANCE_SOURCE_DIR = "\"$(realpath .)/tests/conformance\""
 
 # common flags
 CXXFLAGS=-g -Wall
+CXXFLAGS+=-Wno-missing-field-initializers
 LDFLAGS=
 
 # some gcc versions treat var in `if (type var = val)` as unused


### PR DESCRIPTION
Fixes #1336.

@vegorov-rbx:
> We will disable that warning in the CMake or will accept a PR that disables it.

Adds -Wno-missing-field-initializers to CMakeLists.txt and Makefile.
