### PR TITLE
`__tostring` for `type`

### DIFF
--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -1884,6 +1884,9 @@ static int typeToString(lua_State* L)
 
     TypeFunctionRuntimeBuilderState* runtimeBuilder = Luau::getTypeFunctionRuntime(L)->runtimeBuilder;
     TypeId selfTy = Luau::deserialize(self, runtimeBuilder);
+    if (FFlag::LuauTypeFunctionStructuredErrors ? !runtimeBuilder->errors.empty() : !runtimeBuilder->errors_DEPRECATED.empty())
+        luaL_error(L, "failed to deserialize the self type");
+
     std::string asString = Luau::toString(selfTy);
 
     lua_pushlstring(L, asString.data(), asString.size());

--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -14,6 +14,7 @@
 #include "Luau/TypeFunction.h"
 #include "Luau/TypeFunctionRuntimeBuilder.h"
 #include "Luau/RecursionCounter.h"
+#include "Luau/ToString.h"
 
 #include "lua.h"
 #include "lualib.h"
@@ -31,6 +32,7 @@ LUAU_FASTFLAGVARIABLE(LuauTypeFunctionSerializeArgNames)
 LUAU_FASTFLAGVARIABLE(LuauTypeFunctionRobustness)
 LUAU_FASTFLAGVARIABLE(LuauUdtfTypeIsSubtypeOf)
 LUAU_FASTFLAGVARIABLE(LuauTypeFunctionTableIndexerIsReadOnly)
+LUAU_FASTFLAGVARIABLE(LuauUdtfTypeToStringMetamethod)
 
 namespace Luau
 {
@@ -1874,6 +1876,20 @@ static int isEqualToType(lua_State* L)
     return 1;
 }
 
+// Luau: `tostring(self) -> string`,
+// or other cases where the `__tostring` metamethod is invoked
+static int typeToString(lua_State* L)
+{
+    TypeFunctionTypeId self = getTypeUserData(L, 1);
+
+    TypeFunctionRuntimeBuilderState* runtimeBuilder = Luau::getTypeFunctionRuntime(L)->runtimeBuilder;
+    TypeId selfTy = Luau::deserialize(self, runtimeBuilder);
+    std::string asString = Luau::toString(selfTy);
+
+    lua_pushlstring(L, asString.data(), asString.size());
+    return 1;
+}
+
 void registerTypesLibrary(lua_State* L)
 {
     luaL_Reg fields[] = {
@@ -2042,6 +2058,12 @@ void registerTypeUserData(lua_State* L)
 
     lua_pushcfunction(L, isEqualToType, "__eq");
     lua_setfield(L, -2, "__eq");
+
+    if (FFlag::LuauUdtfTypeToStringMetamethod)
+    {
+        lua_pushcfunction(L, typeToString, "__tostring");
+        lua_setfield(L, -2, "__tostring");
+    }
 
     // Indexing will be a dynamic function because some type fields are dynamic
     lua_newtable(L);

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -20,6 +20,7 @@ LUAU_FASTFLAG(LuauUdtfTypeIsSubtypeOf)
 LUAU_FASTFLAG(LuauTypeFunctionTableIndexerIsReadOnly)
 LUAU_FASTFLAG(LuauReadOnlyIndexers)
 LUAU_DYNAMIC_FASTINT(LuauTypeFunctionSerdeIterationLimit)
+LUAU_FASTFLAG(LuauUdtfTypeToStringMetamethod)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");
 
@@ -3436,6 +3437,33 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "issubtypeof_table_indexer")
     CHECK(toString(requireType("a")) == "false");
     CHECK(toString(requireType("b")) == "false");
     CHECK(toString(requireType("c")) == "true");
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "type_tostring")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    ScopedFastFlag tostringMetamethod{FFlag::LuauUdtfTypeToStringMetamethod, true};
+
+    CheckResult results = check(R"(
+        type function foo(ty)
+            error(tostring(ty))
+        end
+
+        type T<U> = {
+            read absoluteHina: true,
+            [number]: string,
+            t: T<U>
+        }
+
+        local x: foo<T<vector>>
+    )");
+    LUAU_REQUIRE_ERROR_COUNT(1, results);
+
+    CHECK_EQ(
+        toString(results.errors[0]),
+        "'foo' type function errored at runtime: [string \"foo\"]:3: { [number]: string, read absoluteHina: true, t: t1 }"
+            " where t1 = { [number]: string, read absoluteHina: true, t: t1 }"
+    );
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
```luau
type function foo(ty)
    error(tostring(ty))
end

type T<U> = {
    read absoluteHina: true,
    [number]: string,
    t: T<U>
}

local x: foo<T<vector>>
--> "'foo' type function errored at runtime: [string "foo"]:3: { [number]: string, read absoluteHina: true, t: t1 }
--       where t1 = { [number]: string, read absoluteHina: true, t: t1 }"
```

Closes #1667