### PR TITLE
Add default parameters and named call arguments

### DIFF
--- a/Analysis/src/AstJsonEncoder.cpp
+++ b/Analysis/src/AstJsonEncoder.cpp
@@ -240,6 +240,10 @@ struct AstJsonEncoder : public AstVisitor
             write("luauType", local->annotation);
         else
             write("luauType", nullptr);
+        if (local->defaultValue)
+            write("defaultValue", local->defaultValue);
+        if (local->defaultValues.size > 0)
+            write("defaultValues", local->defaultValues);
         write("name", local->name);
         write("isConst", local->isConst);
         writeType("AstLocal");
@@ -397,6 +401,8 @@ struct AstJsonEncoder : public AstVisitor
             {
                 PROP(func);
                 PROP(args);
+                if (node->argNames.size > 0)
+                    PROP(argNames);
                 PROP(self);
                 PROP(argLocation);
             }

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -2828,9 +2828,112 @@ InferencePack ConstraintGenerator::checkExprCall(
 )
 {
     std::vector<AstExpr*> exprArgs;
+    AstArray<AstExpr*> callArgs = call->args;
+    std::vector<AstExpr*> loweredArgs;
+    std::vector<std::unique_ptr<AstExprConstantNil>> nilArgs;
 
     std::vector<RefinementId> returnRefinements;
     std::vector<std::optional<TypeId>> discriminantTypes;
+
+    bool hasNamedArguments = false;
+    for (const std::optional<AstArgumentName>& name : call->argNames)
+    {
+        if (name)
+        {
+            hasNamedArguments = true;
+            break;
+        }
+    }
+
+    if (hasNamedArguments)
+    {
+        TypeId functionType = follow(fnType);
+        if (const IntersectionType* it = get<IntersectionType>(functionType); it && it->parts.size() == 1)
+            functionType = follow(it->parts[0]);
+
+        if (const FunctionType* ftv = get<FunctionType>(functionType))
+        {
+            auto [argsHead, argsTail] = flatten(ftv->argTypes);
+            size_t selfOffset = call->self ? 1 : 0;
+            size_t parameterCount = argsHead.size() > selfOffset ? argsHead.size() - selfOffset : 0;
+            loweredArgs.assign(parameterCount, nullptr);
+
+            std::vector<bool> assigned(parameterCount, false);
+            bool valid = true;
+            bool seenNamed = false;
+            size_t positional = 0;
+
+            for (size_t i = 0; i < call->args.size && valid; ++i)
+            {
+                AstExpr* arg = call->args.data[i];
+                std::optional<AstArgumentName> name = call->argNames.size > i ? call->argNames.data[i] : std::nullopt;
+
+                if (!name)
+                {
+                    if (seenNamed)
+                    {
+                        valid = false;
+                        break;
+                    }
+
+                    while (positional < assigned.size() && assigned[positional])
+                        ++positional;
+
+                    if (positional < parameterCount)
+                    {
+                        loweredArgs[positional] = arg;
+                        assigned[positional] = true;
+                        ++positional;
+                    }
+                    else
+                    {
+                        loweredArgs.push_back(arg);
+                    }
+
+                    continue;
+                }
+
+                seenNamed = true;
+                size_t parameter = parameterCount;
+
+                for (size_t j = 0; j < parameterCount; ++j)
+                {
+                    size_t nameIndex = j + selfOffset;
+                    if (nameIndex < ftv->argNames.size() && ftv->argNames[nameIndex] && ftv->argNames[nameIndex]->name == name->first.value)
+                    {
+                        parameter = j;
+                        break;
+                    }
+                }
+
+                if (parameter == parameterCount || assigned[parameter])
+                {
+                    valid = false;
+                    break;
+                }
+
+                loweredArgs[parameter] = arg;
+                assigned[parameter] = true;
+            }
+
+            if (valid)
+            {
+                while (!loweredArgs.empty() && loweredArgs.back() == nullptr)
+                    loweredArgs.pop_back();
+
+                for (AstExpr*& arg : loweredArgs)
+                {
+                    if (!arg)
+                    {
+                        nilArgs.push_back(std::make_unique<AstExprConstantNil>(call->location));
+                        arg = nilArgs.back().get();
+                    }
+                }
+
+                callArgs = AstArray<AstExpr*>{loweredArgs.data(), loweredArgs.size()};
+            }
+        }
+    }
 
     if (call->self)
     {
@@ -2850,7 +2953,7 @@ InferencePack ConstraintGenerator::checkExprCall(
             discriminantTypes.emplace_back(std::nullopt);
     }
 
-    for (AstExpr* arg : call->args)
+    for (AstExpr* arg : callArgs)
     {
         exprArgs.push_back(arg);
 
@@ -4278,6 +4381,27 @@ ConstraintGenerator::FunctionSignature ConstraintGenerator::checkFunctionSignatu
         argNames.emplace_back(FunctionArgument{local->name.value, local->location});
 
         signatureScope->bindings[local] = Binding{argTy, local->location};
+        if (local->defaultValues.size > 0)
+        {
+            if (const AstTypeUnion* unionAnnotation =
+                    local->defaultValues.size > 1 && local->annotation ? local->annotation->as<AstTypeUnion>() : nullptr)
+            {
+                for (size_t defaultIndex = 0; defaultIndex < local->defaultValues.size; ++defaultIndex)
+                {
+                    TypeId defaultTy = defaultIndex < unionAnnotation->types.size
+                                           ? resolveType(signatureScope, unionAnnotation->types.data[defaultIndex], false, true, Polarity::Negative)
+                                           : argTy;
+                    check(signatureScope, local->defaultValues.data[defaultIndex], defaultTy);
+                }
+            }
+            else
+            {
+                for (AstExpr* defaultValue : local->defaultValues)
+                    check(signatureScope, defaultValue, argTy);
+            }
+        }
+        else if (local->defaultValue)
+            check(signatureScope, local->defaultValue, argTy);
 
         DefId def = dfg->getDef(local);
         signatureScope->lvalueTypes[def] = argTy;
@@ -4357,6 +4481,15 @@ ConstraintGenerator::FunctionSignature ConstraintGenerator::checkFunctionSignatu
     }
 
     // TODO: Preserve argument names in the function's type.
+
+    for (size_t i = FFlag::DebugLuauUserDefinedClasses && hasExplicitSelf ? 1 : 0; i < fn->args.size; ++i)
+    {
+        if (fn->args.data[i]->defaultValue)
+        {
+            size_t argIndex = fn->self ? i + 1 : i;
+            argTypes[argIndex] = makeUnion(signatureScope, fn->args.data[i]->location, argTypes[argIndex], builtinTypes->nilType);
+        }
+    }
 
     FunctionType actualFunction{TypeLevel{}, arena->addTypePack(std::move(argTypes), varargPack), returnType};
     actualFunction.generics = std::move(genericTypes);

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -28,6 +28,7 @@
 #include "Luau/VisitType.h"
 
 #include <algorithm>
+#include <memory>
 #include <sstream>
 
 #include "Luau/Simplify.h"
@@ -1565,7 +1566,6 @@ void TypeChecker2::visitCall(AstExprCall* call)
     TypePack args;
     std::vector<AstExpr*> argExprs;
     NotNull<Scope> scope{findInnermostScope(call->location)};
-    argExprs.reserve(call->args.size + 1);
 
     TypeId* originalCallTy = module->astOriginalCallTypes.find(call->func);
     TypeId* selectedOverloadTy = module->astOverloadResolvedTypes.find(call);
@@ -1617,6 +1617,109 @@ void TypeChecker2::visitCall(AstExprCall* call)
         }
     }
 
+    AstArray<AstExpr*> callArgs = call->args;
+    std::vector<AstExpr*> loweredArgs;
+    std::vector<std::unique_ptr<AstExprConstantNil>> nilArgs;
+
+    bool hasNamedArguments = false;
+    for (const std::optional<AstArgumentName>& name : call->argNames)
+    {
+        if (name)
+        {
+            hasNamedArguments = true;
+            break;
+        }
+    }
+
+    if (hasNamedArguments)
+    {
+        TypeId namedFnTy = follow(fnTy);
+        if (const FunctionType* fty = get<FunctionType>(namedFnTy))
+        {
+            auto [argsHead, argsTail] = flatten(fty->argTypes);
+            size_t selfOffset = call->self ? 1 : 0;
+            size_t parameterCount = argsHead.size() > selfOffset ? argsHead.size() - selfOffset : 0;
+            loweredArgs.assign(parameterCount, nullptr);
+
+            std::vector<bool> assigned(parameterCount, false);
+            bool valid = true;
+            bool seenNamed = false;
+            size_t positional = 0;
+
+            for (size_t i = 0; i < call->args.size && valid; ++i)
+            {
+                AstExpr* arg = call->args.data[i];
+                std::optional<AstArgumentName> name = call->argNames.size > i ? call->argNames.data[i] : std::nullopt;
+
+                if (!name)
+                {
+                    if (seenNamed)
+                    {
+                        valid = false;
+                        break;
+                    }
+
+                    while (positional < assigned.size() && assigned[positional])
+                        ++positional;
+
+                    if (positional < parameterCount)
+                    {
+                        loweredArgs[positional] = arg;
+                        assigned[positional] = true;
+                        ++positional;
+                    }
+                    else
+                    {
+                        loweredArgs.push_back(arg);
+                    }
+
+                    continue;
+                }
+
+                seenNamed = true;
+                size_t parameter = parameterCount;
+
+                for (size_t j = 0; j < parameterCount; ++j)
+                {
+                    size_t nameIndex = j + selfOffset;
+                    if (nameIndex < fty->argNames.size() && fty->argNames[nameIndex] && fty->argNames[nameIndex]->name == name->first.value)
+                    {
+                        parameter = j;
+                        break;
+                    }
+                }
+
+                if (parameter == parameterCount || assigned[parameter])
+                {
+                    valid = false;
+                    break;
+                }
+
+                loweredArgs[parameter] = arg;
+                assigned[parameter] = true;
+            }
+
+            if (valid)
+            {
+                while (!loweredArgs.empty() && loweredArgs.back() == nullptr)
+                    loweredArgs.pop_back();
+
+                for (AstExpr*& arg : loweredArgs)
+                {
+                    if (!arg)
+                    {
+                        nilArgs.push_back(std::make_unique<AstExprConstantNil>(call->location));
+                        arg = nilArgs.back().get();
+                    }
+                }
+
+                callArgs = AstArray<AstExpr*>{loweredArgs.data(), loweredArgs.size()};
+            }
+        }
+    }
+
+    argExprs.reserve(callArgs.size + 1);
+
     if (call->self)
     {
         AstExprIndexName* indexExpr = call->func->as<AstExprIndexName>();
@@ -1632,18 +1735,18 @@ void TypeChecker2::visitCall(AstExprCall* call)
 
     // FIXME: Similar to bidirectional inference prior, this does not support
     // overloaded functions nor generic typeArguments (yet).
-    if (auto fty = get<FunctionType>(fnTy); fty && fty->generics.empty() && fty->genericPacks.empty() && call->args.size > 0)
+    if (auto fty = get<FunctionType>(fnTy); fty && fty->generics.empty() && fty->genericPacks.empty() && callArgs.size > 0)
     {
         size_t selfOffset = call->self ? 1 : 0;
 
-        std::vector<TypeId> paramsHead = extendTypePack(module->internalTypes, builtinTypes, fty->argTypes, call->args.size + selfOffset).head;
+        std::vector<TypeId> paramsHead = extendTypePack(module->internalTypes, builtinTypes, fty->argTypes, callArgs.size + selfOffset).head;
 
-        for (size_t idx = 0; idx < call->args.size; ++idx)
+        for (size_t idx = 0; idx < callArgs.size; ++idx)
         {
-            AstExpr* argExpr = call->args.data[idx];
+            AstExpr* argExpr = callArgs.data[idx];
 
             // The last argument might be an ordinary value, but it can also be an entire pack.
-            if (idx == call->args.size - 1)
+            if (idx == callArgs.size - 1)
             {
                 if (TypePackId* lastArgPack = module->astTypePacks.find(argExpr))
                 {
@@ -1667,14 +1770,14 @@ void TypeChecker2::visitCall(AstExprCall* call)
     }
     else
     {
-        for (size_t i = 0; i < call->args.size; ++i)
+        for (size_t i = 0; i < callArgs.size; ++i)
         {
-            AstExpr* arg = call->args.data[i];
+            AstExpr* arg = callArgs.data[i];
             argExprs.push_back(arg);
             TypeId* argTy = module->astTypes.find(arg);
             if (argTy)
                 args.head.push_back(*argTy);
-            else if (i == call->args.size - 1)
+            else if (i == callArgs.size - 1)
             {
                 if (auto argTail = module->astTypePacks.find(arg))
                 {
@@ -2068,14 +2171,37 @@ void TypeChecker2::visit(AstExprFunction* fn)
 
             TypeId inferredArgTy = *argIt;
 
+            TypeId annotatedArgTy = nullptr;
+
             if (arg->annotation)
             {
                 // we need to typecheck any argument annotations themselves.
                 visit(arg->annotation);
 
-                TypeId annotatedArgTy = lookupAnnotation(arg->annotation);
+                annotatedArgTy = lookupAnnotation(arg->annotation);
 
                 testIsSubtype(inferredArgTy, annotatedArgTy, arg->location);
+            }
+
+            if (arg->defaultValues.size > 0)
+            {
+                const AstTypeUnion* unionAnnotation =
+                    arg->defaultValues.size > 1 && arg->annotation ? arg->annotation->as<AstTypeUnion>() : nullptr;
+                for (size_t defaultIndex = 0; defaultIndex < arg->defaultValues.size; ++defaultIndex)
+                {
+                    AstExpr* defaultValue = arg->defaultValues.data[defaultIndex];
+                    TypeId defaultTy = unionAnnotation && defaultIndex < unionAnnotation->types.size
+                                           ? lookupAnnotation(unionAnnotation->types.data[defaultIndex])
+                                           : annotatedArgTy ? annotatedArgTy
+                                                            : inferredArgTy;
+                    visit(defaultValue, ValueContext::RValue);
+                    testIsSubtype(lookupType(defaultValue), defaultTy, defaultValue->location);
+                }
+            }
+            else if (arg->defaultValue)
+            {
+                visit(arg->defaultValue, ValueContext::RValue);
+                testIsSubtype(lookupType(arg->defaultValue), annotatedArgTy ? annotatedArgTy : inferredArgTy, arg->defaultValue->location);
             }
 
             // Some Luau constructs can result in an argument type being

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 
 LUAU_FASTFLAGVARIABLE(DebugLuauMagicTypes)
 LUAU_FASTINTVARIABLE(LuauTypeInferRecursionLimit, 165)
@@ -4025,7 +4026,26 @@ std::pair<TypeId, ScopePtr> TypeChecker::checkFunctionSignature(
         }
 
         funScope->bindings[local] = {argType, local->location};
-        argTypes.push_back(argType);
+        if (local->defaultValues.size > 0)
+        {
+            if (const AstTypeUnion* unionAnnotation =
+                    local->defaultValues.size > 1 && local->annotation ? local->annotation->as<AstTypeUnion>() : nullptr)
+            {
+                for (size_t defaultIndex = 0; defaultIndex < local->defaultValues.size; ++defaultIndex)
+                {
+                    TypeId defaultType = defaultIndex < unionAnnotation->types.size ? resolveType(funScope, *unionAnnotation->types.data[defaultIndex]) : argType;
+                    checkExpr(funScope, *local->defaultValues.data[defaultIndex], defaultType);
+                }
+            }
+            else
+            {
+                for (AstExpr* defaultValue : local->defaultValues)
+                    checkExpr(funScope, *defaultValue, argType);
+            }
+        }
+        else if (local->defaultValue)
+            checkExpr(funScope, *local->defaultValue, argType);
+        argTypes.push_back(local->defaultValue ? unionOfTypes(argType, nilType, funScope, local->location, false) : argType);
 
         if (expectedArgsCurr != expectedArgsEnd)
             ++expectedArgsCurr;
@@ -4527,9 +4547,109 @@ WithPredicate<TypePackId> TypeChecker::checkExprPackHelper(const ScopePtr& scope
 
         std::vector<TypeId> overloads = flattenIntersection(actualFunctionType);
 
-        std::vector<std::optional<TypeId>> expectedTypes = getExpectedTypesForCall(overloads, expr.args.size, expr.self);
+        AstArray<AstExpr*> callArgs = expr.args;
+        std::vector<AstExpr*> loweredArgs;
+        std::vector<std::unique_ptr<AstExprConstantNil>> nilArgs;
 
-        WithPredicate<TypePackId> argListResult = checkExprList(scope, expr.location, expr.args, false, {}, expectedTypes);
+        bool hasNamedArguments = false;
+        for (const std::optional<AstArgumentName>& name : expr.argNames)
+        {
+            if (name)
+            {
+                hasNamedArguments = true;
+                break;
+            }
+        }
+
+        if (hasNamedArguments && overloads.size() == 1)
+        {
+            if (const FunctionType* ftv = get<FunctionType>(follow(overloads[0])))
+            {
+                auto [argsHead, argsTail] = flatten(ftv->argTypes);
+                size_t selfOffset = expr.self ? 1 : 0;
+                size_t parameterCount = argsHead.size() > selfOffset ? argsHead.size() - selfOffset : 0;
+                loweredArgs.assign(parameterCount, nullptr);
+
+                std::vector<bool> assigned(parameterCount, false);
+                bool valid = true;
+                bool seenNamed = false;
+                size_t positional = 0;
+
+                for (size_t i = 0; i < expr.args.size && valid; ++i)
+                {
+                    AstExpr* arg = expr.args.data[i];
+                    std::optional<AstArgumentName> name = expr.argNames.size > i ? expr.argNames.data[i] : std::nullopt;
+
+                    if (!name)
+                    {
+                        if (seenNamed)
+                        {
+                            valid = false;
+                            break;
+                        }
+
+                        while (positional < assigned.size() && assigned[positional])
+                            ++positional;
+
+                        if (positional < parameterCount)
+                        {
+                            loweredArgs[positional] = arg;
+                            assigned[positional] = true;
+                            ++positional;
+                        }
+                        else
+                        {
+                            loweredArgs.push_back(arg);
+                        }
+
+                        continue;
+                    }
+
+                    seenNamed = true;
+                    size_t parameter = parameterCount;
+
+                    for (size_t j = 0; j < parameterCount; ++j)
+                    {
+                        size_t nameIndex = j + selfOffset;
+                        if (nameIndex < ftv->argNames.size() && ftv->argNames[nameIndex] && ftv->argNames[nameIndex]->name == name->first.value)
+                        {
+                            parameter = j;
+                            break;
+                        }
+                    }
+
+                    if (parameter == parameterCount || assigned[parameter])
+                    {
+                        valid = false;
+                        break;
+                    }
+
+                    loweredArgs[parameter] = arg;
+                    assigned[parameter] = true;
+                }
+
+                if (valid)
+                {
+                    while (!loweredArgs.empty() && loweredArgs.back() == nullptr)
+                        loweredArgs.pop_back();
+
+                    for (AstExpr*& arg : loweredArgs)
+                    {
+                        if (!arg)
+                        {
+                            nilArgs.push_back(std::make_unique<AstExprConstantNil>(expr.location));
+                            arg = nilArgs.back().get();
+                        }
+                    }
+
+                    callArgs = AstArray<AstExpr*>{loweredArgs.data(), loweredArgs.size()};
+                }
+            }
+        }
+
+        std::vector<std::optional<TypeId>> expectedTypes = getExpectedTypesForCall(overloads, callArgs.size, expr.self);
+
+        WithPredicate<TypePackId> argListResult = checkExprList(scope, expr.location, callArgs, false, {}, expectedTypes);
         TypePackId argPack = argListResult.type;
 
         if (get<ErrorTypePack>(argPack))
@@ -4545,10 +4665,10 @@ WithPredicate<TypePackId> TypeChecker::checkExprPackHelper(const ScopePtr& scope
         LUAU_ASSERT(args);
 
         std::vector<Location> argLocations;
-        argLocations.reserve(expr.args.size + 1);
+        argLocations.reserve(callArgs.size + 1);
         if (expr.self)
             argLocations.push_back(expr.func->as<AstExprIndexName>()->expr->location);
-        for (AstExpr* arg : expr.args)
+        for (AstExpr* arg : callArgs)
             argLocations.push_back(arg->location);
 
         std::vector<OverloadErrorEntry> errors; // errors encountered for each overload

--- a/Ast/include/Luau/Ast.h
+++ b/Ast/include/Luau/Ast.h
@@ -67,39 +67,6 @@ class AstTypePack;
 class AstAttr;
 class AstExprTable;
 
-struct AstLocal
-{
-    AstName name;
-    Location location;
-    AstLocal* shadow;
-    size_t functionDepth;
-    size_t loopDepth;
-    bool isConst;
-    // exported is only a property set after construction
-    bool isExported = false;
-
-    AstType* annotation;
-
-    AstLocal(
-        const AstName& name,
-        const Location& location,
-        AstLocal* shadow,
-        size_t functionDepth,
-        size_t loopDepth,
-        AstType* annotation,
-        bool isConst = false
-    )
-        : name(name)
-        , location(location)
-        , shadow(shadow)
-        , functionDepth(functionDepth)
-        , loopDepth(loopDepth)
-        , isConst(isConst)
-        , annotation(annotation)
-    {
-    }
-};
-
 template<typename T>
 struct AstArray
 {
@@ -124,6 +91,45 @@ struct AstArray
     std::reverse_iterator<const T*> rend() const
     {
         return std::make_reverse_iterator(begin());
+    }
+};
+
+struct AstLocal
+{
+    AstName name;
+    Location location;
+    AstLocal* shadow;
+    size_t functionDepth;
+    size_t loopDepth;
+    bool isConst;
+    // exported is only a property set after construction
+    bool isExported = false;
+
+    AstType* annotation;
+    AstExpr* defaultValue;
+    AstArray<AstExpr*> defaultValues;
+
+    AstLocal(
+        const AstName& name,
+        const Location& location,
+        AstLocal* shadow,
+        size_t functionDepth,
+        size_t loopDepth,
+        AstType* annotation,
+        AstExpr* defaultValue = nullptr,
+        const AstArray<AstExpr*>& defaultValues = {},
+        bool isConst = false
+    )
+        : name(name)
+        , location(location)
+        , shadow(shadow)
+        , functionDepth(functionDepth)
+        , loopDepth(loopDepth)
+        , isConst(isConst)
+        , annotation(annotation)
+        , defaultValue(defaultValue)
+        , defaultValues(defaultValues)
+    {
     }
 };
 
@@ -458,7 +464,8 @@ public:
         const AstArray<AstExpr*>& args,
         bool self,
         const AstArray<AstTypeOrPack>& explicitTypes,
-        const Location& argLocation
+        const Location& argLocation,
+        const AstArray<std::optional<AstArgumentName>>& argNames = {}
     );
 
     void visit(AstVisitor* visitor) override;
@@ -469,6 +476,7 @@ public:
     // which is then called.
     AstArray<AstTypeOrPack> typeArguments;
     AstArray<AstExpr*> args;
+    AstArray<std::optional<AstArgumentName>> argNames;
     bool self;
     Location argLocation;
 };

--- a/Ast/include/Luau/Parser.h
+++ b/Ast/include/Luau/Parser.h
@@ -234,9 +234,8 @@ private:
 
     // explist ::= {exp `,'} exp
     void parseExprList(TempVector<AstExpr*>& result, TempVector<Position>* commaPositions = nullptr);
-
-    // binding ::= Name [`:` Type]
-    Binding parseBinding(bool isConst = false);
+    // binding ::= Name [`:` Type] [`=' expr]
+    Binding parseBinding(bool isConst = false, bool allowDefault = false);
     AstArray<Position> extractAnnotationColonPositions(const TempVector<Binding>& bindings);
 
     // bindinglist ::= (binding | `...') {`,' bindinglist}
@@ -247,7 +246,8 @@ private:
         AstArray<Position>* commaPositions = nullptr,
         Position* initialCommaPosition = nullptr,
         Position* varargAnnotationColonPosition = nullptr,
-        bool isConst = false
+        bool isConst = false,
+        bool allowDefault = false
     );
 
     AstType* parseOptionalType();
@@ -506,12 +506,23 @@ private:
     {
         Name name;
         AstType* annotation;
+        AstExpr* defaultValue;
+        AstArray<AstExpr*> defaultValues;
         Position colonPosition;
         bool isConst;
 
-        explicit Binding(const Name& name, AstType* annotation = nullptr, Position colonPosition = {0, 0}, bool isConst = false)
+        explicit Binding(
+            const Name& name,
+            AstType* annotation = nullptr,
+            AstExpr* defaultValue = nullptr,
+            AstArray<AstExpr*> defaultValues = {},
+            Position colonPosition = {0, 0},
+            bool isConst = false
+        )
             : name(name)
             , annotation(annotation)
+            , defaultValue(defaultValue)
+            , defaultValues(defaultValues)
             , colonPosition(colonPosition)
             , isConst(isConst)
         {

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -239,12 +239,14 @@ AstExprCall::AstExprCall(
     const AstArray<AstExpr*>& args,
     bool self,
     const AstArray<AstTypeOrPack>& explicitTypes,
-    const Location& argLocation
+    const Location& argLocation,
+    const AstArray<std::optional<AstArgumentName>>& argNames
 )
     : AstExpr(ClassIndex(), location)
     , func(func)
     , typeArguments(explicitTypes)
     , args(args)
+    , argNames(argNames)
     , self(self)
     , argLocation(argLocation)
 {
@@ -341,6 +343,13 @@ void AstExprFunction::visit(AstVisitor* visitor)
         {
             if (arg->annotation)
                 arg->annotation->visit(visitor);
+            if (arg->defaultValues.size > 0)
+            {
+                for (AstExpr* defaultValue : arg->defaultValues)
+                    defaultValue->visit(visitor);
+            }
+            else if (arg->defaultValue)
+                arg->defaultValue->visit(visitor);
         }
 
         if (varargAnnotation)

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -6,6 +6,7 @@
 #include "Luau/TimeTrace.h"
 
 #include <algorithm>
+#include <memory>
 
 #include <errno.h>
 #include <limits.h>
@@ -1568,7 +1569,7 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
     // We save the locals here as part of error recovery later.
     auto savedLocals = saveLocals();
 
-    AstLocal* nameLocal = pushLocal(Binding(*name, nullptr, {0, 0}, true));
+    AstLocal* nameLocal = pushLocal(Binding(*name, nullptr, nullptr, {}, {0, 0}, true));
 
     TempVector<AstClassMember> declarations(scratchClassDeclarations);
 
@@ -2330,9 +2331,18 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
     {
         if (cstNode)
             std::tie(vararg, varargLocation, varargAnnotation) =
-                parseBindingList(args, /* allowDot3= */ true, &cstNode->argsCommaPositions, nullptr, &cstNode->varargAnnotationColonPosition);
+                parseBindingList(
+                    args,
+                    /* allowDot3= */ true,
+                    &cstNode->argsCommaPositions,
+                    nullptr,
+                    &cstNode->varargAnnotationColonPosition,
+                    /* isConst= */ false,
+                    /* allowDefault= */ true
+                );
         else
-            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true);
+            std::tie(vararg, varargLocation, varargAnnotation) =
+                parseBindingList(args, /* allowDot3= */ true, nullptr, nullptr, nullptr, /* isConst= */ false, /* allowDefault= */ true);
     }
 
     std::optional<Location> argLocation;
@@ -2350,7 +2360,7 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
 
     if (localName)
     {
-        funLocal = pushLocal(Binding(*localName, nullptr, {0, 0}, isConst));
+        funLocal = pushLocal(Binding(*localName, nullptr, nullptr, {}, {0, 0}, isConst));
     }
 
     unsigned int localsBegin = saveLocals();
@@ -2420,7 +2430,7 @@ void Parser::parseExprList(TempVector<AstExpr*>& result, TempVector<Position>* c
     }
 }
 
-Parser::Binding Parser::parseBinding(bool isConst)
+Parser::Binding Parser::parseBinding(bool isConst, bool allowDefault)
 {
     std::optional<Name> name = parseNameOpt("variable name");
 
@@ -2430,11 +2440,29 @@ Parser::Binding Parser::parseBinding(bool isConst)
 
     Position colonPosition = lexer.current().type == ':' ? lexer.current().location.begin : Position::missing();
     AstType* annotation = parseOptionalType();
+    AstExpr* defaultValue = nullptr;
+    AstArray<AstExpr*> defaultValues;
+
+    if (allowDefault && lexer.current().type == '=')
+    {
+        nextLexeme();
+        TempVector<AstExpr*> values(scratchExpr);
+        values.push_back(parseExpr());
+
+        while (lexer.current().type == '|')
+        {
+            nextLexeme();
+            values.push_back(parseExpr());
+        }
+
+        defaultValue = values.front();
+        defaultValues = copy(values);
+    }
 
     if (options.storeCstData)
-        return Binding(*name, annotation, colonPosition, isConst);
+        return Binding(*name, annotation, defaultValue, defaultValues, colonPosition, isConst);
     else
-        return Binding(*name, annotation, Position::missing(), isConst);
+        return Binding(*name, annotation, defaultValue, defaultValues, Position::missing(), isConst);
 }
 
 AstArray<Position> Parser::extractAnnotationColonPositions(const TempVector<Binding>& bindings)
@@ -2452,7 +2480,8 @@ LUAU_NOINLINE std::tuple<bool, Location, AstTypePack*> Parser::parseBindingList(
     AstArray<Position>* commaPositions,
     Position* initialCommaPosition,
     Position* varargAnnotationColonPosition,
-    bool isConst
+    bool isConst,
+    bool allowDefault
 )
 {
     TempVector<Position> localCommaPositions(scratchPosition);
@@ -2483,7 +2512,7 @@ LUAU_NOINLINE std::tuple<bool, Location, AstTypePack*> Parser::parseBindingList(
             return {true, varargLocation, tailAnnotation};
         }
 
-        result.push_back(parseBinding(isConst));
+        result.push_back(parseBinding(isConst, allowDefault));
 
         if (lexer.current().type != ',')
             break;
@@ -4166,10 +4195,47 @@ AstExpr* Parser::parseFunctionArgs(AstExpr* func, bool self)
         nextLexeme();
 
         TempVector<AstExpr*> args(scratchExpr);
+        std::unique_ptr<TempVector<std::optional<AstArgumentName>>> argNames;
         TempVector<Position> commaPositions(scratchPosition);
 
         if (lexer.current().type != ')')
-            parseExprList(args, options.storeCstData ? &commaPositions : nullptr);
+        {
+            while (true)
+            {
+                if (lexer.current().type == Lexeme::Name && lexer.lookahead().type == '=')
+                {
+                    if (!argNames)
+                    {
+                        argNames = std::make_unique<TempVector<std::optional<AstArgumentName>>>(scratchOptArgName);
+                        for (size_t i = 0; i < args.size(); ++i)
+                            argNames->push_back(std::nullopt);
+                    }
+
+                    Name name = parseName("argument name");
+                    expectAndConsume('=', "named argument");
+                    argNames->push_back(AstArgumentName{name.name, name.location});
+                    args.push_back(parseExpr());
+                }
+                else
+                {
+                    if (argNames)
+                        argNames->push_back(std::nullopt);
+                    args.push_back(parseExpr());
+                }
+
+                if (lexer.current().type != ',')
+                    break;
+                if (options.storeCstData)
+                    commaPositions.push_back(lexer.current().location.begin);
+                nextLexeme();
+
+                if (lexer.current().type == ')')
+                {
+                    report(lexer.current().location, "Expected expression after ',' but got ')' instead");
+                    break;
+                }
+            }
+        }
 
         Location end = lexer.current().location;
         Position argEnd = end.end;
@@ -4177,7 +4243,13 @@ AstExpr* Parser::parseFunctionArgs(AstExpr* func, bool self)
         bool closingParenFound = expectMatchAndConsume(')', matchParen);
 
         AstExprCall* node = allocator.alloc<AstExprCall>(
-            Location(func->location, end), func, copy(args), self, AstArray<AstTypeOrPack>{}, Location(argStart, argEnd)
+            Location(func->location, end),
+            func,
+            copy(args),
+            self,
+            AstArray<AstTypeOrPack>{},
+            Location(argStart, argEnd),
+            argNames ? copy(*argNames) : AstArray<std::optional<AstArgumentName>>{}
         );
         if (options.storeCstData)
             cstNodeMap[node] = allocator.alloc<CstExprCall>(
@@ -5023,7 +5095,15 @@ AstLocal* Parser::pushLocal(const Binding& binding)
     AstLocal*& local = localMap[name.name];
 
     local = allocator.alloc<AstLocal>(
-        name.name, name.location, /* shadow= */ local, functionStack.size() - 1, functionStack.back().loopDepth, binding.annotation, binding.isConst
+        name.name,
+        name.location,
+        /* shadow= */ local,
+        functionStack.size() - 1,
+        functionStack.back().loopDepth,
+        binding.annotation,
+        binding.defaultValue,
+        binding.defaultValues,
+        binding.isConst
     );
 
     localStack.push_back(local);

--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -583,10 +583,17 @@ struct Printer
                 writer.symbol("(");
 
             CommaSeparatorInserter comma(writer, cstNode ? cstNode->commaPositions.begin() : nullptr);
-            for (const auto& arg : a->args)
+            for (size_t i = 0; i < a->args.size; ++i)
             {
                 comma();
-                visualize(*arg);
+                if (a->argNames.size > i && a->argNames.data[i])
+                {
+                    const AstArgumentName& name = *a->argNames.data[i];
+                    advance(name.second.begin);
+                    writer.identifier(name.first.value);
+                    writer.symbol("=");
+                }
+                visualize(*a->args.data[i]);
             }
 
             if (cstNode)
@@ -1504,6 +1511,22 @@ struct Printer
                     writer.symbol(":");
 
                 visualizeTypeAnnotation(*local->annotation);
+            }
+
+            if (local->defaultValues.size > 0)
+            {
+                writer.symbol("=");
+                for (size_t defaultIndex = 0; defaultIndex < local->defaultValues.size; ++defaultIndex)
+                {
+                    if (defaultIndex > 0)
+                        writer.symbol("|");
+                    visualize(*local->defaultValues.data[defaultIndex]);
+                }
+            }
+            else if (local->defaultValue)
+            {
+                writer.symbol("=");
+                visualize(*local->defaultValue);
             }
         }
 

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <memory>
 
 #include <math.h>
 
@@ -135,7 +136,7 @@ struct Compiler
         , exprTypes(nullptr)
         , builtinTypes(options.vectorType)
         , names(names)
-        , exportTableLocal(names.getOrAdd("__EXP"), Location(), nullptr, 0, 0, nullptr, true)
+        , exportTableLocal(names.getOrAdd("__EXP"), Location(), nullptr, 0, 0, nullptr, nullptr, {}, true)
     {
         // preallocate some buffers that are very likely to grow anyway; this works around std::vector's inefficient growth policy for small arrays
         localStack.reserve(16);
@@ -318,6 +319,107 @@ struct Compiler
             return node->as<AstExprFunction>();
     }
 
+    bool hasNamedArguments(AstExprCall* expr)
+    {
+        for (const std::optional<AstArgumentName>& name : expr->argNames)
+        {
+            if (name)
+                return true;
+        }
+
+        return false;
+    }
+
+    bool hasDefaultArguments(AstExprFunction* func)
+    {
+        for (AstLocal* arg : func->args)
+        {
+            if (arg->defaultValue)
+                return true;
+        }
+
+        return false;
+    }
+
+    AstExprCall lowerNamedCall(
+        AstExprCall* expr,
+        AstExprFunction* func,
+        std::vector<AstExpr*>& loweredArgs,
+        std::vector<std::unique_ptr<AstExprConstantNil>>& nilArgs
+    )
+    {
+        loweredArgs.assign(func->args.size, nullptr);
+
+        std::vector<bool> assigned(func->args.size, false);
+        bool seenNamed = false;
+        size_t positional = 0;
+
+        for (size_t i = 0; i < expr->args.size; ++i)
+        {
+            AstExpr* arg = expr->args.data[i];
+            std::optional<AstArgumentName> name = expr->argNames.size > i ? expr->argNames.data[i] : std::nullopt;
+
+            if (!name)
+            {
+                if (seenNamed)
+                    CompileError::raise(arg->location, "Positional arguments cannot follow named arguments");
+
+                while (positional < assigned.size() && assigned[positional])
+                    ++positional;
+
+                if (positional < func->args.size)
+                {
+                    loweredArgs[positional] = arg;
+                    assigned[positional] = true;
+                    ++positional;
+                }
+                else
+                {
+                    loweredArgs.push_back(arg);
+                }
+
+                continue;
+            }
+
+            seenNamed = true;
+            size_t parameter = func->args.size;
+
+            for (size_t j = 0; j < func->args.size; ++j)
+            {
+                if (func->args.data[j]->name == name->first)
+                {
+                    parameter = j;
+                    break;
+                }
+            }
+
+            if (parameter == func->args.size)
+                CompileError::raise(name->second, "Unknown named argument '%s'", name->first.value);
+            if (assigned[parameter])
+                CompileError::raise(name->second, "Duplicate argument for parameter '%s'", name->first.value);
+
+            loweredArgs[parameter] = arg;
+            assigned[parameter] = true;
+        }
+
+        while (!loweredArgs.empty() && loweredArgs.back() == nullptr)
+            loweredArgs.pop_back();
+
+        for (AstExpr*& arg : loweredArgs)
+        {
+            if (!arg)
+            {
+                nilArgs.push_back(std::make_unique<AstExprConstantNil>(expr->location));
+                arg = nilArgs.back().get();
+            }
+        }
+
+        AstExprCall lowered = *expr;
+        lowered.args = AstArray<AstExpr*>{loweredArgs.data(), loweredArgs.size()};
+        lowered.argNames = AstArray<std::optional<AstArgumentName>>{};
+        return lowered;
+    }
+
     void compileExportTable()
     {
         LUAU_ASSERT(!exportedLocals.empty() || !exportedClasses.empty());
@@ -381,6 +483,27 @@ struct Compiler
         bytecode.emitABC(LOP_RETURN, freezeReg, 2, 0);
     }
 
+    void compileDefaultArguments(AstExprFunction* func)
+    {
+        for (AstLocal* local : func->args)
+        {
+            if (!local->defaultValue)
+                continue;
+
+            int reg = getLocalReg(local);
+            LUAU_ASSERT(reg >= 0);
+
+            size_t skipLabel = bytecode.emitLabel();
+            bytecode.emitAD(LOP_JUMPXEQKNIL, uint8_t(reg), 0);
+            bytecode.emitAux(0x80000000);
+
+            compileExprTemp(local->defaultValue, uint8_t(reg));
+
+            size_t endLabel = bytecode.emitLabel();
+            patchJump(func, skipLabel, endLabel);
+        }
+    }
+
     uint32_t compileFunction(AstExprFunction* func, uint8_t& protoflags)
     {
         LUAU_TIMETRACE_SCOPE("Compiler::compileFunction", "Compiler");
@@ -412,6 +535,7 @@ struct Compiler
             pushLocal(func->args.data[i], uint8_t(args + self + i), kDefaultAllocPc);
 
         argCount = localStack.size();
+        compileDefaultArguments(func);
 
         AstStatBlock* stat = func->body;
 
@@ -522,7 +646,7 @@ struct Compiler
         f.upvals = upvals;
 
         // record information for inlining
-        if (options.optimizationLevel >= 2 && !func->vararg && !func->self && !getfenvUsed && !setfenvUsed)
+        if (options.optimizationLevel >= 2 && !func->vararg && !func->self && !getfenvUsed && !setfenvUsed && !hasDefaultArguments(func))
         {
             if (FFlag::DebugLuauNoInline && func->hasAttribute(AstAttr::Type::DebugNoinline))
             {
@@ -1153,6 +1277,18 @@ struct Compiler
         LUAU_ASSERT(!targetTop || unsigned(target + targetCount) == regTop);
 
         setDebugLine(expr); // normally compileExpr sets up line info, but compileExprCall can be called directly
+
+        if (hasNamedArguments(expr))
+        {
+            AstExprFunction* func = getFunctionExpr(expr->func);
+            if (!func)
+                CompileError::raise(expr->location, "Named arguments require a statically known function");
+
+            std::vector<AstExpr*> loweredArgs;
+            std::vector<std::unique_ptr<AstExprConstantNil>> nilArgs;
+            AstExprCall lowered = lowerNamedCall(expr, func, loweredArgs, nilArgs);
+            return compileExprCall(&lowered, target, targetCount, targetTop, multRet);
+        }
 
         // try inlining the function
         if (options.optimizationLevel >= 2 && !expr->self)

--- a/tests/AstJsonEncoder.test.cpp
+++ b/tests/AstJsonEncoder.test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("basic_escaping")
 
 TEST_CASE("encode_AstStatBlock")
 {
-    AstLocal astlocal{AstName{"a_local"}, Location(), nullptr, 0, 0, nullptr, false};
+    AstLocal astlocal{AstName{"a_local"}, Location(), nullptr, 0, 0, nullptr};
     AstLocal* astlocalarray[] = {&astlocal};
 
     AstArray<AstLocal*> vars{astlocalarray, 1};
@@ -201,7 +201,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstExprInterpString")
 
 TEST_CASE("encode_AstExprLocal")
 {
-    AstLocal local{AstName{"foo"}, Location{}, nullptr, 0, 0, nullptr, false};
+    AstLocal local{AstName{"foo"}, Location{}, nullptr, 0, 0, nullptr};
     AstExprLocal exprLocal{Location{}, &local, false};
 
     CHECK(

--- a/tests/LValue.test.cpp
+++ b/tests/LValue.test.cpp
@@ -175,13 +175,13 @@ TEST_CASE_FIXTURE(LValueFixture, "hashing_lvalue_local_prop_access")
     std::string t1 = "t";
     std::string x1 = "x";
 
-    AstLocal localt1{AstName{t1.data()}, Location(), nullptr, 0, 0, nullptr, false};
+    AstLocal localt1{AstName{t1.data()}, Location(), nullptr, 0, 0, nullptr};
     LValue t_x1{Field{std::make_shared<LValue>(Symbol{&localt1}), x1}};
 
     std::string t2 = "t";
     std::string x2 = "x";
 
-    AstLocal localt2{AstName{t2.data()}, Location(), &localt1, 0, 0, nullptr, false};
+    AstLocal localt2{AstName{t2.data()}, Location(), &localt1, 0, 0, nullptr};
     LValue t_x2{Field{std::make_shared<LValue>(Symbol{&localt2}), x2}};
 
     CHECK_EQ(t_x1, t_x1);

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -5869,5 +5869,41 @@ TEST_CASE_FIXTURE(Fixture, "extern_read_write_attributes")
     CHECK_EQ(declaredExternType->props.data[3].access, AstTableAccess::ReadWrite);
 }
 
+TEST_CASE_FIXTURE(Fixture, "default_parameters_and_named_call_arguments")
+{
+    ParseResult result = tryParse(R"(
+local function example(x: number = 0, y: number = 1, z: number = 2, w: number | string = 4 | "fallback")
+end
+
+example(0, z = 3, w = "set")
+    )");
+
+    REQUIRE(result.errors.empty());
+    REQUIRE_EQ(result.root->body.size, 2);
+
+    AstStatLocalFunction* localFunction = result.root->body.data[0]->as<AstStatLocalFunction>();
+    REQUIRE(localFunction);
+    REQUIRE_EQ(localFunction->func->args.size, 4);
+    CHECK(localFunction->func->args.data[0]->defaultValue->is<AstExprConstantNumber>());
+    CHECK(localFunction->func->args.data[1]->defaultValue->is<AstExprConstantNumber>());
+    CHECK(localFunction->func->args.data[2]->defaultValue->is<AstExprConstantNumber>());
+    REQUIRE_EQ(localFunction->func->args.data[3]->defaultValues.size, 2);
+    CHECK(localFunction->func->args.data[3]->defaultValues.data[0]->is<AstExprConstantNumber>());
+    CHECK(localFunction->func->args.data[3]->defaultValues.data[1]->is<AstExprConstantString>());
+
+    AstStatExpr* callStat = result.root->body.data[1]->as<AstStatExpr>();
+    REQUIRE(callStat);
+
+    AstExprCall* call = callStat->expr->as<AstExprCall>();
+    REQUIRE(call);
+    REQUIRE_EQ(call->args.size, 3);
+    REQUIRE_EQ(call->argNames.size, 3);
+    CHECK(!call->argNames.data[0]);
+    REQUIRE(call->argNames.data[1]);
+    CHECK(call->argNames.data[1]->first == "z");
+    REQUIRE(call->argNames.data[2]);
+    CHECK(call->argNames.data[2]->first == "w");
+}
+
 // TODO unit tests for various parse errors.
 TEST_SUITE_END();

--- a/tests/Symbol.test.cpp
+++ b/tests/Symbol.test.cpp
@@ -45,8 +45,8 @@ TEST_CASE("equality_and_hashing_of_locals")
     std::string s2 = "name";
 
     // These two names point to distinct memory areas.
-    AstLocal one{AstName{s1.data()}, Location(), nullptr, 0, 0, nullptr, false};
-    AstLocal two{AstName{s2.data()}, Location(), &one, 0, 0, nullptr, false};
+    AstLocal one{AstName{s1.data()}, Location(), nullptr, 0, 0, nullptr};
+    AstLocal two{AstName{s2.data()}, Location(), &one, 0, 0, nullptr};
 
     Symbol n1{&one};
     Symbol n2{&two};
@@ -74,7 +74,7 @@ TEST_CASE("equality_of_empty_symbols")
     std::string s2 = "name";
 
     AstName one{s1.data()};
-    AstLocal two{AstName{s2.data()}, Location(), nullptr, 0, 0, nullptr, false};
+    AstLocal two{AstName{s2.data()}, Location(), nullptr, 0, 0, nullptr};
 
     Symbol global{one};
     Symbol local{&two};

--- a/tests/conformance/calls.luau
+++ b/tests/conformance/calls.luau
@@ -226,6 +226,32 @@ assert((function () return nil end)(4) == nil)
 assert((function () local a; return a end)(4) == nil)
 assert((function (a) return a end)() == nil)
 
+do
+  local function defaults(x: number = 10, y: number = 20, z: number = 30)
+    return x, y, z
+  end
+
+  local x, y, z = defaults()
+  assert(x == 10 and y == 20 and z == 30)
+
+  x, y, z = defaults(1, nil, 3)
+  assert(x == 1 and y == 20 and z == 3)
+
+  x, y, z = defaults(z = 5)
+  assert(x == 10 and y == 20 and z == 5)
+
+  x, y, z = defaults(1, z = 5)
+  assert(x == 1 and y == 20 and z == 5)
+
+  local function unionDefault(value: number | string = 10 | "fallback")
+    return value
+  end
+
+  assert(unionDefault() == 10)
+  assert(unionDefault(nil) == 10)
+  assert(unionDefault("set") == "set")
+end
+
  -- test for a bug in clobbering stack variables 
  -- this call to print will clobber x and y if the call to f is not properly setup
 local function clobber()


### PR DESCRIPTION
## Summary

This adds support for default function parameters and named call arguments in Luau.

Default parameters allow omitted or explicitly `nil` arguments to fall back to a parameter default. Named call arguments are parsed and lowered to positional arguments at compile time, so runtime calls remain ordinary positional calls.

## Examples

```luau
local function vec3(x: number = 0, y: number = 0, z: number = 0)
    return { x, y, z }
end

vec3()            -- {0, 0, 0}
vec3(5, nil, 9)  -- {5, 0, 9}
vec3(z = 12)     -- {0, 0, 12}
vec3(1, z = 3)   -- {1, 0, 3}
```

Pipe separated defaults are also parsed and preserved for union typed parameters:

```luau
local function value(v: number | string = 10 | "fallback")
    return v
end
```

## Implementation Notes

- Extends function parameter bindings with default expressions.
- Extends call expressions with optional argument names.
- Parses `name: Type = default` in function parameter lists.
- Parses named call arguments such as `foo(x = 1, z = 3)`.
- Lowers named call arguments to positional arguments during compilation/type analysis.
- Emits a nil check prologue for parameters with defaults.
- Preserves defaults in AST visiting, pretty printing, and JSON encoding.
- Updates old and new typechecker paths to validate default expressions against annotated parameter types.
- Functions with defaults are currently excluded from inlining to avoid incorrect optimization around prologue defaults.

## Performance

Existing ordinary calls remain on the existing fast path. A bytecode check confirms ordinary calls can still be inlined, while defaulted functions emit explicit nil check prologue instructions.

Named arguments are compile time lowering only, there is no runtime name table lookup.

Local RelWithDebInfo microbenchmark, 5M calls:

```text
plain inline:      0.040603s
plain noinline:    0.126828s
default full args: 0.164476s
default nil arg:   0.182494s
default named:     0.202034s
```

The expected overhead is limited to functions that declare defaults. Ordinary existing functions are not meaningfully affected.

## Validation

```text
Luau.UnitTest: 4963 passed, 0 failed
Luau.Conformance calls.luau: 293 passed, 0 failed
git diff --check: clean except existing LF/CRLF working copy warnings
```

## Current Constraints

- Named arguments currently require a statically known function expression so they can be lowered safely.
- For pipe separated default lists on union parameters, the AST preserves the list and typechecks defaults by union arm, while runtime fallback uses the first default because omitted or nil arguments do not carry runtime type information.