### PR TITLE
Update build.yml to run faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       if: matrix.os.name == 'ubuntu'
     - name: make tests
       run: |
-        CC=${{matrix.compiler.cc}} CXX=${{matrix.compiler.cxx}} make -j2 config=sanitize werror=1 native=1 luau-tests
+        CC=${{matrix.compiler.cc}} CXX=${{matrix.compiler.cxx}} make -j4 config=sanitize werror=1 native=1 luau-tests
     - name: run tests
       run: |
         ./luau-tests
@@ -52,7 +52,7 @@ jobs:
         ./luau-tests -ts=Conformance --codegen -O2 --fflags=true
     - name: make cli
       run: |
-         make -j2 config=sanitize werror=1 luau luau-analyze luau-compile # match config with tests to improve build time
+         make -j4 config=sanitize werror=1 luau luau-analyze luau-compile # match config with tests to improve build time
          ./luau tests/conformance/assert.luau
          ./luau-analyze tests/conformance/assert.luau
          ./luau-compile tests/conformance/assert.luau
@@ -67,7 +67,7 @@ jobs:
     - name: cmake configure
       run: cmake . -A ${{matrix.arch}} -DLUAU_WERROR=ON -DLUAU_NATIVE=ON
     - name: cmake build
-      run: cmake --build . --target Luau.UnitTest Luau.Conformance --config Debug
+      run: cmake --build . --target Luau.UnitTest Luau.Conformance --config Debug -j 4
     - name: run tests
       shell: bash # necessary for fail-fast
       run: |
@@ -87,7 +87,7 @@ jobs:
     - name: cmake cli
       shell: bash # necessary for fail-fast
       run: |
-        cmake --build . --target Luau.Repl.CLI Luau.Analyze.CLI Luau.Compile.CLI --config Debug # match config with tests to improve build time
+        cmake --build . --target Luau.Repl.CLI Luau.Analyze.CLI Luau.Compile.CLI --config Debug -j 4 # match config with tests to improve build time
         Debug/luau tests/conformance/assert.luau
         Debug/luau-analyze tests/conformance/assert.luau
         Debug/luau-compile tests/conformance/assert.luau
@@ -101,7 +101,7 @@ jobs:
         sudo apt install llvm
     - name: make coverage
       run: |
-        CXX=clang++ make -j2 config=coverage native=1 coverage
+        CXX=clang++ make -j4 config=coverage native=1 coverage
     - name: upload coverage
       uses: codecov/codecov-action@v3
       with:
@@ -125,4 +125,4 @@ jobs:
       run: |
         source emsdk/emsdk_env.sh
         emcmake cmake . -DLUAU_BUILD_WEB=ON -DCMAKE_BUILD_TYPE=Release
-        make -j2 Luau.Web
+        make -j4 Luau.Web


### PR DESCRIPTION
GitHub allows 3-4 cores for public repositories now, so let's update.
