### PR TITLE
Fix `integer.create` and `fromstring` type definitions

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -343,7 +343,7 @@ declare vector: {
 static const char* const kBuiltinDefinitionIntegerSrc = R"BUILTIN_SRC(
 
 declare integer: {
-    create: @checked (x: number) -> integer,
+    create: @checked (x: number) -> integer?,
     tonumber: @checked (x: integer) -> number,
     neg: @checked (value: integer) -> integer,
     add: @checked (x: integer, y: integer) -> integer,
@@ -381,7 +381,7 @@ declare integer: {
     countrz: @checked (x: integer) -> integer,
     countlz: @checked (x: integer) -> integer,
     bswap: @checked (x: integer) -> integer,
-    fromstring: @checked (str: string, base: number?) -> integer,
+    fromstring: @checked (str: string, base: number?) -> integer?,
     minsigned: integer,
     maxsigned: integer
 }

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -6,6 +6,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauUdtfTypeIsSubtypeOf)
+LUAU_FASTFLAGVARIABLE(LuauBetterIntegerAnalysis)
 
 namespace Luau
 {
@@ -388,6 +389,54 @@ declare integer: {
 
 )BUILTIN_SRC";
 
+static const char* const kBuiltinDefinitionIntegerSrc_DEPRECATED = R"BUILTIN_SRC(
+
+declare integer: {
+    create: @checked (x: number) -> integer,
+    tonumber: @checked (x: integer) -> number,
+    neg: @checked (value: integer) -> integer,
+    add: @checked (x: integer, y: integer) -> integer,
+    sub: @checked (x: integer, y: integer) -> integer,
+    mul: @checked (x: integer, y: integer) -> integer,
+    div: @checked (x: integer, y: integer) -> integer,
+    rem: @checked (x: integer, y: integer) -> integer,
+    idiv: @checked (x: integer, y: integer) -> integer,
+    mod: @checked (x: integer, y: integer) -> integer,
+    udiv: @checked (x: integer, y: integer) -> integer,
+    urem: @checked (x: integer, y: integer) -> integer,
+    min: @checked (integer, ...integer) -> integer,
+    max: @checked (integer, ...integer) -> integer,
+    band: @checked (...integer) -> integer,
+    bor: @checked (...integer) -> integer,
+    bnot: @checked (x: integer) -> integer,
+    bxor: @checked (...integer) -> integer,
+    lt: @checked (x: integer, y: integer) -> boolean,
+    le: @checked (x: integer, y: integer) -> boolean,
+    ult: @checked (x: integer, y: integer) -> boolean,
+    ule: @checked (x: integer, y: integer) -> boolean,
+    gt: @checked (x: integer, y: integer) -> boolean,
+    ge: @checked (x: integer, y: integer) -> boolean,
+    ugt: @checked (x: integer, y: integer) -> boolean,
+    uge: @checked (x: integer, y: integer) -> boolean,
+    lshift: @checked (x: integer, numBitPositions: integer) -> integer,
+    rshift: @checked (x: integer, numBitPositions: integer) -> integer,
+    arshift: @checked (x: integer, numBitPositions: integer) -> integer,
+    lrotate: @checked (x: integer, numBitPositions: integer) -> integer,
+    rrotate: @checked (x: integer, numBitPositions: integer) -> integer,
+    extract: @checked (value: integer, bitPosition: integer, numBits: integer?) -> integer,
+    replace: @checked (value: integer, replacement: integer, bitPosition: integer, numBits: integer?) -> integer,
+    clamp: @checked (value: integer, min: integer, max: integer) -> integer,
+    btest: @checked (...integer) -> boolean,
+    countrz: @checked (x: integer) -> integer,
+    countlz: @checked (x: integer) -> integer,
+    bswap: @checked (x: integer) -> integer,
+    fromstring: @checked (str: string, base: number?) -> integer,
+    minsigned: integer,
+    maxsigned: integer
+}
+
+)BUILTIN_SRC";
+
 static const char* kBuiltinDefinitionClassSrc = R"CLASS_SRC(
 declare class: {
     isinstance: @checked (o: unknown, c: class) -> boolean,
@@ -415,7 +464,10 @@ std::string getBuiltinDefinitionSource()
 
     if (FFlag::LuauIntegerType2 && FFlag::LuauIntegerLibrary)
     {
-        result += kBuiltinDefinitionIntegerSrc;
+        if (FFlag::LuauBetterIntegerAnalysis)
+            result += kBuiltinDefinitionIntegerSrc;
+        else
+            result += kBuiltinDefinitionIntegerSrc_DEPRECATED;
     }
 
     if (FFlag::DebugLuauUserDefinedClasses && FFlag::LuauAllowGlobalDeclarationToBeCalledClass)

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -5,6 +5,7 @@ LUAU_FASTFLAG(LuauIntegerLibrary)
 LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
+LUAU_FASTFLAGVARIABLE(LuauBetterIntegerAnalysis)
 
 namespace Luau
 {
@@ -387,6 +388,54 @@ declare integer: {
 
 )BUILTIN_SRC";
 
+static const char* const kBuiltinDefinitionIntegerSrc_DEPRECATED = R"BUILTIN_SRC(
+
+declare integer: {
+    create: @checked (x: number) -> integer,
+    tonumber: @checked (x: integer) -> number,
+    neg: @checked (value: integer) -> integer,
+    add: @checked (x: integer, y: integer) -> integer,
+    sub: @checked (x: integer, y: integer) -> integer,
+    mul: @checked (x: integer, y: integer) -> integer,
+    div: @checked (x: integer, y: integer) -> integer,
+    rem: @checked (x: integer, y: integer) -> integer,
+    idiv: @checked (x: integer, y: integer) -> integer,
+    mod: @checked (x: integer, y: integer) -> integer,
+    udiv: @checked (x: integer, y: integer) -> integer,
+    urem: @checked (x: integer, y: integer) -> integer,
+    min: @checked (integer, ...integer) -> integer,
+    max: @checked (integer, ...integer) -> integer,
+    band: @checked (...integer) -> integer,
+    bor: @checked (...integer) -> integer,
+    bnot: @checked (x: integer) -> integer,
+    bxor: @checked (...integer) -> integer,
+    lt: @checked (x: integer, y: integer) -> boolean,
+    le: @checked (x: integer, y: integer) -> boolean,
+    ult: @checked (x: integer, y: integer) -> boolean,
+    ule: @checked (x: integer, y: integer) -> boolean,
+    gt: @checked (x: integer, y: integer) -> boolean,
+    ge: @checked (x: integer, y: integer) -> boolean,
+    ugt: @checked (x: integer, y: integer) -> boolean,
+    uge: @checked (x: integer, y: integer) -> boolean,
+    lshift: @checked (x: integer, numBitPositions: integer) -> integer,
+    rshift: @checked (x: integer, numBitPositions: integer) -> integer,
+    arshift: @checked (x: integer, numBitPositions: integer) -> integer,
+    lrotate: @checked (x: integer, numBitPositions: integer) -> integer,
+    rrotate: @checked (x: integer, numBitPositions: integer) -> integer,
+    extract: @checked (value: integer, bitPosition: integer, numBits: integer?) -> integer,
+    replace: @checked (value: integer, replacement: integer, bitPosition: integer, numBits: integer?) -> integer,
+    clamp: @checked (value: integer, min: integer, max: integer) -> integer,
+    btest: @checked (...integer) -> boolean,
+    countrz: @checked (x: integer) -> integer,
+    countlz: @checked (x: integer) -> integer,
+    bswap: @checked (x: integer) -> integer,
+    fromstring: @checked (str: string, base: number?) -> integer,
+    minsigned: integer,
+    maxsigned: integer
+}
+
+)BUILTIN_SRC";
+
 static const char* kBuiltinDefinitionClassSrc = R"CLASS_SRC(
 declare class: {
     isinstance: @checked (o: unknown, c: class) -> boolean,
@@ -414,7 +463,10 @@ std::string getBuiltinDefinitionSource()
 
     if (FFlag::LuauIntegerType2 && FFlag::LuauIntegerLibrary)
     {
-        result += kBuiltinDefinitionIntegerSrc;
+        if (FFlag::LuauBetterIntegerAnalysis)
+            result += kBuiltinDefinitionIntegerSrc;
+        else
+            result += kBuiltinDefinitionIntegerSrc_DEPRECATED;
     }
 
     if (FFlag::DebugLuauUserDefinedClasses && FFlag::LuauAllowGlobalDeclarationToBeCalledClass)

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -342,7 +342,7 @@ declare vector: {
 static const char* const kBuiltinDefinitionIntegerSrc = R"BUILTIN_SRC(
 
 declare integer: {
-    create: @checked (x: number) -> integer,
+    create: @checked (x: number) -> integer?,
     tonumber: @checked (x: integer) -> number,
     neg: @checked (value: integer) -> integer,
     add: @checked (x: integer, y: integer) -> integer,
@@ -380,7 +380,7 @@ declare integer: {
     countrz: @checked (x: integer) -> integer,
     countlz: @checked (x: integer) -> integer,
     bswap: @checked (x: integer) -> integer,
-    fromstring: @checked (str: string, base: number?) -> integer,
+    fromstring: @checked (str: string, base: number?) -> integer?,
     minsigned: integer,
     maxsigned: integer
 }


### PR DESCRIPTION
`integer.create` and `integer.fromstring` can return nil, but the embedded type definitions don't reflect that:
```luau
> integer.create(5.4)
nil
> integer.fromstring("w")
nil
```

The embedded definitions also mismatch [the integer RFC](https://rfcs.luau.org/type-long-integer.html#library), where they are both documented to return `integer?`, and not `integer`.

---

Example program to demonstrate why this is a problem:
```luau
--!strict
local function add_ints(a: string, b: string): integer
    return integer.add(integer.fromstring(a), integer.fromstring(b))
end
return add_ints("1.1", "2.2")
```
This program really needs to check that it's not adding nil numbers:
```
$ luau integer-bug.luau 
./integer-bug.luau:3: invalid argument #1 to 'add' (integer expected, got nil)
stacktrace:
[C] function add
./integer-bug.luau:3 function add_ints
./integer-bug.luau:5
```
But the typechecker doesn't notice
```
$ luau-analyze integer-bug.luau 
# no errors
```
After this change, the typechecker also gives a warning:
```
$ luau-analyze integer-bug.luau 
./integer-bug.luau(3,24): TypeError: Expected this to be 'integer', but got 'integer?'; 
the 2nd component of the union is `nil`, which is not a subtype of `integer`
./integer-bug.luau(3,24): TypeError: Expected this to be 'integer', but got 'nil'
```

---

I don't expect this change will need a FFlag, as integers are still experimental, but I'll add one if requested
