### PR TITLE
improve stringification of metatable types

### DIFF
--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -861,12 +861,12 @@ struct TypeStringifier
             return;
         }
 
-        state.emit("{ @metatable ");
-        stringify(mtv.metatable);
+        state.emit("setmetatable< ");
+        stringify(mtv.table);
         state.emit(",");
         state.newline();
-        stringify(mtv.table);
-        state.emit(" }");
+        stringify(mtv.metatable);
+        state.emit(" >");
     }
 
     void operator()(TypeId ty, const ExternType& etv)

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -861,12 +861,12 @@ struct TypeStringifier
             return;
         }
 
-        state.emit("setmetatable< ");
+        state.emit("setmetatable<");
         stringify(mtv.table);
         state.emit(",");
         state.newline();
         stringify(mtv.metatable);
-        state.emit(" >");
+        state.emit(">");
     }
 
     void operator()(TypeId ty, const ExternType& etv)

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -39,6 +39,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
  */
 LUAU_FASTINTVARIABLE(DebugLuauVerboseTypeNames, 0)
 LUAU_FASTFLAGVARIABLE(DebugLuauToStringNoLexicalSort)
+LUAU_FASTFLAGVARIABLE(LuauBetterMetatableStringification)
 
 namespace Luau
 {
@@ -861,12 +862,24 @@ struct TypeStringifier
             return;
         }
 
-        state.emit("setmetatable<");
-        stringify(mtv.table);
-        state.emit(",");
-        state.newline();
-        stringify(mtv.metatable);
-        state.emit(">");
+        if (FFlag::LuauBetterMetatableStringification)
+        {
+            state.emit("setmetatable<");
+            stringify(mtv.table);
+            state.emit(",");
+            state.newline();
+            stringify(mtv.metatable);
+            state.emit(">");
+        }
+        else
+        {
+            state.emit("{ @metatable ");
+            stringify(mtv.metatable);
+            state.emit(",");
+            state.newline();
+            stringify(mtv.table);
+            state.emit(" }");
+        }
     }
 
     void operator()(TypeId ty, const ExternType& etv)

--- a/tests/Fixture.h
+++ b/tests/Fixture.h
@@ -25,6 +25,8 @@
 #include <optional>
 #include <vector>
 
+LUAU_FASTFLAG(LuauBetterMetatableStringification);
+
 LUAU_FASTFLAG(DebugLuauFreezeArena)
 LUAU_FASTFLAG(DebugLuauForceAllNewSolverTests)
 LUAU_FASTFLAG(DebugLuauForceAllOldSolverTests)
@@ -176,6 +178,7 @@ struct Fixture
 
     // lots of tests might use declare class in type definitions - disable this and force all tests to adopt the new syntax
     ScopedFastFlag sff_LuauDisallowExternClassInTypeDefinitions{FFlag::LuauDisallowExternClassInTypeDefinitions, true};
+    ScopedFastFlag sff_LuauBetterMetatableStringification{FFlag::LuauBetterMetatableStringification, true};
 
     TestFileResolver fileResolver;
     TestConfigResolver configResolver;

--- a/tests/Normalize.test.cpp
+++ b/tests/Normalize.test.cpp
@@ -844,7 +844,7 @@ TEST_CASE_FIXTURE(NormalizeFixture, "narrow_union_of_extern_types_with_intersect
 
 TEST_CASE_FIXTURE(NormalizeFixture, "intersection_of_metatables_where_the_metatable_is_top_or_bottom")
 {
-    CHECK("{ @metatable *error-type*, {  } }" == toString(normal("Mt<{}, any> & Mt<{}, err>")));
+    CHECK("setmetatable<{  }, *error-type*>" == toString(normal("Mt<{}, any> & Mt<{}, err>")));
 }
 
 TEST_CASE_FIXTURE(NormalizeFixture, "recurring_intersection")

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -145,7 +145,7 @@ TEST_CASE_FIXTURE(Fixture, "metatable")
     Type table{TypeVariant(TableType())};
     Type metatable{TypeVariant(TableType())};
     Type mtv{TypeVariant(MetatableType{&table, &metatable})};
-    CHECK_EQ("{ @metatable {|  |}, {|  |} }", toString(&mtv));
+    CHECK_EQ("setmetatable<{|  |}, {|  |}>", toString(&mtv));
 }
 
 TEST_CASE_FIXTURE(Fixture, "named_metatable")
@@ -204,7 +204,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "exhaustive_toString_of_cyclic_table")
         CHECK(
             "t2 where "
             "t1 = { __index: t1, __mul: ((t2, number) -> t2) & ((t2, t2) -> t2), new: () -> t2 } ; "
-            "t2 = { @metatable t1, { x: number, y: number, z: number } }" == a
+            "t2 = setmetatable<{ x: number, y: number, z: number }, t1>" == a
         );
     }
     else
@@ -212,7 +212,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "exhaustive_toString_of_cyclic_table")
         CHECK_EQ(
             "t2 where "
             "t1 = {| __index: t1, __mul: ((t2, number) -> t2) & ((t2, t2) -> t2), new: () -> t2 |} ; "
-            "t2 = { @metatable t1, { x: number, y: number, z: number } }",
+            "t2 = setmetatable<{ x: number, y: number, z: number }, t1>",
             a
         );
     }

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -1428,7 +1428,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_type_function_assigns_correct_m
     LUAU_REQUIRE_NO_ERRORS(result);
 
     TypeId id = requireTypeAlias("Identity");
-    CHECK_EQ(toString(id, {true}), "{ @metatable { __index: {  } }, {  } }");
+    CHECK_EQ(toString(id, {true}), "setmetatable<{  }, { __index: {  } }>");
     const MetatableType* mt = get<MetatableType>(id);
     REQUIRE(mt);
     CHECK_EQ(toString(mt->metatable), "{ __index: {  } }");
@@ -1447,7 +1447,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_type_function_assigns_correct_m
     LUAU_REQUIRE_NO_ERRORS(result);
 
     TypeId id = requireTypeAlias("Identity");
-    CHECK_EQ(toString(id, {true}), "{ @metatable { __index: {  } }, {  } }");
+    CHECK_EQ(toString(id, {true}), "setmetatable<{  }, { __index: {  } }>");
     const MetatableType* mt = get<MetatableType>(id);
     REQUIRE(mt);
     CHECK_EQ(toString(mt->metatable), "{ __index: {  } }");
@@ -1455,7 +1455,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_type_function_assigns_correct_m
     TypeId foobar = requireTypeAlias("FooBar");
     const MetatableType* mt2 = get<MetatableType>(foobar);
     REQUIRE(mt2);
-    CHECK_EQ(toString(mt2->metatable, {true}), "{ @metatable { __index: {  } }, {  } }");
+    CHECK_EQ(toString(mt2->metatable, {true}), "setmetatable<{  }, { __index: {  } }>");
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_type_function_errors_on_metatable_with_metatable_metamethod")
@@ -1471,7 +1471,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_type_function_errors_on_metatab
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
     TypeId id = requireTypeAlias("Identity");
-    CHECK_EQ(toString(id, {true}), "{ @metatable { __metatable: \"blocked\" }, {  } }");
+    CHECK_EQ(toString(id, {true}), "setmetatable<{  }, { __metatable: \"blocked\" }>");
     const MetatableType* mt = get<MetatableType>(id);
     REQUIRE(mt);
     CHECK_EQ(toString(mt->metatable), "{ __metatable: \"blocked\" }");

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -915,7 +915,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_check_mutability")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
     REQUIRE(tm);
-    CHECK(toString(tm->givenType) == "{ @metatable {boolean}, {  } }");
+    CHECK(toString(tm->givenType) == "setmetatable<{  }, {boolean}>");
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_copy_works")
@@ -947,7 +947,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_copy_works")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
     REQUIRE(tm);
-    CHECK(toString(tm->givenType) == "{ @metatable { [number]: boolean, string: number }, {  } }");
+    CHECK(toString(tm->givenType) == "setmetatable<{  }, { [number]: boolean, string: number }>");
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_simple_cyclic_serialization_works")
@@ -1486,7 +1486,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_serialization")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK(toString(result.errors[0]) == R"(Expected this to be 'number', but got '{ @metatable { ma: boolean }, { a: number } }')");
+    CHECK(toString(result.errors[0]) == R"(Expected this to be 'number', but got 'setmetatable<{ a: number }, { ma: boolean }>')");
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "nonstrict_mode")

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -387,9 +387,9 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_on_union_of_tables")
 
     LUAU_REQUIRE_NO_ERRORS(result);
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK("{ @metatable {  }, A } | { @metatable {  }, B }" == toString(requireTypeAlias("X")));
+        CHECK("setmetatable<A, {  }> | setmetatable<B, {  }>" == toString(requireTypeAlias("X")));
     else
-        CHECK("{ @metatable {|  |}, A } | { @metatable {|  |}, B }" == toString(requireTypeAlias("X")));
+        CHECK("setmetatable<A, {|  |}> | setmetatable<B, {  }>" == toString(requireTypeAlias("X")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "table_insert_correctly_infers_type_of_array_2_args_overload")

--- a/tests/TypeInfer.oop.test.cpp
+++ b/tests/TypeInfer.oop.test.cpp
@@ -396,9 +396,9 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "augmenting_an_unsealed_table_with_a_metatabl
     )");
 
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK("{ @metatable { number: number }, { method: (unknown) -> string } }" == toString(requireType("B"), {true}));
+        CHECK("setmetatable<{ method: (unknown) -> string }, { number: number }>" == toString(requireType("B"), {true}));
     else
-        CHECK("{ @metatable {| number: number |}, {| method: <a>(a) -> string |} }" == toString(requireType("B"), {true}));
+        CHECK("setmetatable<{| method: <a>(a) -> string |}, {| number: number |}>" == toString(requireType("B"), {true}));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "react_style_oo")
@@ -597,7 +597,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cross_module_metatable")
 
     TypeId clsType = clsBinding->typeId;
 
-    CHECK("{ @metatable cls, tbl }" == toString(clsType));
+    CHECK("setmetatable<tbl, cls>" == toString(clsType));
 }
 
 // https://luau.org/typecheck#adding-types-for-faux-object-oriented-programs
@@ -760,7 +760,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_disallows_invalid_upcast")
     auto err = get<TypeMismatch>(results.errors[0]);
     REQUIRE(err);
     CHECK_EQ("{ const: number }", toString(err->wantedType));
-    CHECK_EQ("{ @metatable t1, {  } } where t1 = { __index: t1, const: number }", toString(err->givenType, {/* exhaustive */ true}));
+    CHECK_EQ("setmetatable<{  }, t1> where t1 = { __index: t1, const: number }", toString(err->givenType, {/* exhaustive */ true}));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_precedence_for_subtyping")
@@ -783,7 +783,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_precedence_for_subtyping")
     auto err = get<TypeMismatch>(results.errors[0]);
     REQUIRE(err);
     CHECK_EQ("{ read foo: string }", toString(err->wantedType, {/* exhaustive */ true}));
-    CHECK_EQ("{ @metatable { __index: { bar: boolean, foo: string } }, { foo: number } }", toString(err->givenType, {/* exhaustive */ true}));
+    CHECK_EQ("setmetatable<{ foo: number }, { __index: { bar: boolean, foo: string } }>", toString(err->givenType, {/* exhaustive */ true}));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "assign_to_prop_of_intersection_of_metatables")

--- a/tests/TypeInfer.provisional.test.cpp
+++ b/tests/TypeInfer.provisional.test.cpp
@@ -1374,7 +1374,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "function_indexer_satisfies_reading_property"
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     auto err = get<TypeMismatch>(result.errors[0]);
     REQUIRE(err);
-    CHECK_EQ("{ @metatable { __index: (unknown, string) -> number }, {  } }", toString(err->givenType, {/* exhaustive */ true}));
+    CHECK_EQ("setmetatable<{  }, { __index: (unknown, string) -> number }>", toString(err->givenType, {/* exhaustive */ true}));
     CHECK_EQ("{ read X: number }", toString(err->wantedType));
 }
 

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -2658,7 +2658,7 @@ b()
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
-    CHECK_EQ(toString(result.errors[0]), R"(Cannot call a value of type t1 where t1 = { @metatable {| __call: t1 |}, {|  |} })");
+    CHECK_EQ(toString(result.errors[0]), R"(Cannot call a value of type t1 where t1 = setmetatalbe<{|  |}, {| __call: t1 |}>)");
 }
 
 TEST_CASE_FIXTURE(Fixture, "table_subtyping_shouldn't_add_optional_properties_to_sealed_tables")
@@ -3911,7 +3911,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_has_a_side_effect")
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
-    CHECK(toString(requireType("foo")) == "{ @metatable mt, foo }");
+    CHECK(toString(requireType("foo")) == "setmetatable<foo, mt>");
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "tables_should_be_fully_populated")
@@ -5255,9 +5255,9 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "subtyping_with_a_metatable_table_path")
     CHECK("Type function instance setmetatable<unknown, unknown> is uninhabited" == toString(result.errors.at(2)));
 
     CHECK(
-        "Expected this to be 'setmetatable<unknown, unknown>', but got '{ @metatable {  }, {  } & {  } }'; \n"
-        "the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces to "
-        "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`" == toString(result.errors.at(3))
+        "Expected this to be 'setmetatable<unknown, unknown>', but got 'setmetatable<{  } & {  }, {  }>'; \n"
+        "the 1st entry in the type pack is `setmetatable<{  } & {  }, {  }>` and in the 1st entry in the type packreduces to "
+        "`never`, and `setmetatable<{  } & {  }, {  }>` is not a subtype of `never`" == toString(result.errors.at(3))
     );
 }
 
@@ -5281,8 +5281,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_union_type")
     )");
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK_EQ(
-        "Cannot add indexer to table '{ @metatable t1, (nil & ~(false?)) | {  } } where t1 = { new: <a>(a) -> { @metatable t1, (a & ~(false?)) | {  "
-        "} } }'",
+        "Cannot add indexer to table 'setmetatable<(nil & ~(false?)) | {  }, t1> where t1 = { new: <a>(a) -> setmetatable<(a & ~(false?)) | {  }, t1> }'",
         toString(result.errors[0])
     );
 }

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -2658,7 +2658,7 @@ b()
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
-    CHECK_EQ(toString(result.errors[0]), R"(Cannot call a value of type t1 where t1 = setmetatalbe<{|  |}, {| __call: t1 |}>)");
+    CHECK_EQ(toString(result.errors[0]), R"(Cannot call a value of type t1 where t1 = setmetatable<{|  |}, {| __call: t1 |}>)");
 }
 
 TEST_CASE_FIXTURE(Fixture, "table_subtyping_shouldn't_add_optional_properties_to_sealed_tables")

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -5281,7 +5281,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_union_type")
     )");
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK_EQ(
-        "Cannot add indexer to table 'setmetatable<(nil & ~(false?)) | {  }, t1> where t1 = { new: <a>(a) -> setmetatable<(a & ~(false?)) | {  }, t1> }'",
+        "Cannot add indexer to table 'setmetatable<(nil & ~(false?)) | {  }, t1> where t1 = { new: <a>(a) -> setmetatable<(a & ~(false?)) | {  }, "
+        "t1> }'",
         toString(result.errors[0])
     );
 }

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -1886,7 +1886,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "getmetatable_infer_any_param")
     if (!FFlag::DebugLuauForceOldSolver)
         CHECK_EQ("(unknown) -> any", toString(requireType("check")));
     else
-        CHECK_EQ("({ @metatable any, {+  +} }) -> any", toString(requireType("check")));
+        CHECK_EQ("(setmetatable<{+  +}, any>) -> any", toString(requireType("check")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "fuzzer_pack_check_missing_follow")

--- a/tests/TypeInfer.typestates.test.cpp
+++ b/tests/TypeInfer.typestates.test.cpp
@@ -880,7 +880,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_depends_on_sub_expression")
 
     auto err = get<TypeMismatch>(result.errors[0]);
     REQUIRE(err);
-    CHECK_EQ("setmetatable<{ foo: number }, { bar: number }>", toString(err->wantedType, { /* exhaustive */ true}));
+    CHECK_EQ("setmetatable<{ foo: number }, { bar: number }>", toString(err->wantedType, {/* exhaustive */ true}));
     CHECK_EQ("{ foo: number }", toString(err->givenType, { /* exhaustive */ true}));
 }
 

--- a/tests/TypeInfer.typestates.test.cpp
+++ b/tests/TypeInfer.typestates.test.cpp
@@ -880,7 +880,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "setmetatable_depends_on_sub_expression")
 
     auto err = get<TypeMismatch>(result.errors[0]);
     REQUIRE(err);
-    CHECK_EQ("{ @metatable { bar: number }, { foo: number } }", toString(err->wantedType, { /* exhaustive */ true}));
+    CHECK_EQ("setmetatable<{ foo: number }, { bar: number }>", toString(err->wantedType, { /* exhaustive */ true}));
     CHECK_EQ("{ foo: number }", toString(err->givenType, { /* exhaustive */ true}));
 }
 


### PR DESCRIPTION
- closes #2544
- changes `{ @metatable {  }, {  } }` to `setmetatable<{  }, {  }>`
- i updated and ran tests on NixOS 26.05 x86_64 w/ `make test`
- although this could possibly be conflated w an unsolved built-in type function i think the mental model here should be the same
- this (very small) change is 100% human written