### PR TITLE
partially implement type:setreadindexer

### DIFF
--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -1117,7 +1117,11 @@ static int setTableReadIndexer(lua_State* L)
 
     int argumentCount = lua_gettop(L);
     if (argumentCount == 2 && get<TypeFunctionNeverType>(getTypeUserData(L, 2)))
-        luaL_error(L, "type.setreadindexer: expected 3 arguments, but got 2; the key was types.never, did you mean to do :setreadindexer(types.never, types.never)?");
+        luaL_error(
+            L,
+            "type.setreadindexer: expected 3 arguments, but got 2; the key was types.never, did you mean to do :setreadindexer(types.never, "
+            "types.never)?"
+        );
     if (argumentCount != 3)
         luaL_error(L, "type.setreadindexer: expected 3 arguments, but got %d", argumentCount);
 

--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -34,6 +34,7 @@ LUAU_FASTFLAGVARIABLE(LuauTypeFunctionTableIndexerIsReadOnly)
 LUAU_FASTFLAGVARIABLE(LuauUdtfCreateSingletonFixErrorMessage)
 LUAU_FASTFLAGVARIABLE(LuauUdtfTypeUseTaggedMetatable)
 LUAU_FASTFLAGVARIABLE(LuauUdtfTypeToStringMetamethod)
+LUAU_FASTFLAGVARIABLE(LuauUdtfTypeSetReadIndexerMethod)
 
 namespace Luau
 {
@@ -1111,7 +1112,31 @@ static int setTableIndexer(lua_State* L)
 // Sets the read indexer of the table
 static int setTableReadIndexer(lua_State* L)
 {
-    luaL_error(L, "type.setreadindexer: luau does not yet support separate read/write types for indexers.");
+    if (!(FFlag::LuauUdtfTypeSetReadIndexerMethod && FFlag::LuauTypeFunctionTableIndexerIsReadOnly))
+        luaL_error(L, "type.setreadindexer: this function is not enabled yet");
+
+    int argumentCount = lua_gettop(L);
+    if (argumentCount == 2 && get<TypeFunctionNeverType>(getTypeUserData(L, 2)))
+        luaL_error(L, "type.setreadindexer: expected 3 arguments, but got 2; the key was types.never, did you mean to do :setreadindexer(types.never, types.never)?");
+    if (argumentCount != 3)
+        luaL_error(L, "type.setreadindexer: expected 3 arguments, but got %d", argumentCount);
+
+    TypeFunctionTypeId self = getTypeUserData(L, 1);
+    auto tftt = getMutable<TypeFunctionTableType>(self);
+    if (!tftt)
+        luaL_error(L, "type.setreadindexer: expected self to be either a table, but got %s instead", getTag(L, self).c_str());
+
+    if (FFlag::LuauTypeFunctionSupportsFrozen && self->frozen)
+        luaL_error(L, "type.setreadindexer: cannot be called to mutate a frozen type, use `types.copy` to make a copy");
+
+    TypeFunctionTypeId key = getTypeUserData(L, 2);
+    if (tftt->indexer && !tftt->indexer->isReadOnly)
+        luaL_error(L, "types.setreadindexer: the table has an existing read+write indexer, which luau does not support setreadindexer for yet");
+
+    TypeFunctionTypeId value = getTypeUserData(L, 3);
+
+    tftt->indexer = TypeFunctionTableIndexer{key, value, true};
+    return 0;
 }
 
 // Luau: `self:setwriteindexer(key: type, value: type)`

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -3554,11 +3554,13 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "type_setreadindexer_errors_when_existing_rea
     LUAU_REQUIRE_ERROR_COUNT(2, results);
     CHECK_EQ(
         toString(results.errors[0]),
-        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: types.setreadindexer: the table has an existing read+write indexer, which luau does not support setreadindexer for yet"
+        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: types.setreadindexer: the table has an existing read+write indexer, which "
+        "luau does not support setreadindexer for yet"
     );
     CHECK_EQ(
         toString(results.errors[1]),
-        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: types.setreadindexer: the table has an existing read+write indexer, which luau does not support setreadindexer for yet"
+        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: types.setreadindexer: the table has an existing read+write indexer, which "
+        "luau does not support setreadindexer for yet"
     );
 }
 

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -21,6 +21,7 @@ LUAU_FASTFLAG(LuauReadOnlyIndexers)
 LUAU_DYNAMIC_FASTINT(LuauTypeFunctionSerdeIterationLimit)
 LUAU_FASTFLAG(LuauUdtfCreateSingletonFixErrorMessage)
 LUAU_FASTFLAG(LuauUdtfTypeToStringMetamethod)
+LUAU_FASTFLAG(LuauUdtfTypeSetReadIndexerMethod)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");
 
@@ -3477,6 +3478,87 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "types_singleton_error_message")
     CHECK_EQ(
         toString(results.errors[0]),
         "'meow' type function errored at runtime: [string \"meow\"]:4: types.singleton: can't create a singleton from a type"
+    );
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "type_setreadindexer_works_for_newtable")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD()
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauUdtfTypeSetReadIndexerMethod, true},
+        {FFlag::LuauTypeFunctionTableIndexerIsReadOnly, true},
+        {FFlag::LuauReadOnlyIndexers, true},
+    };
+
+    CheckResult results = check(R"(
+        type function meow(index: type, value: type)
+            local new = types.newtable()
+            new:setreadindexer(index, value)
+            return new
+        end
+
+        local a: meow<number, string>
+        local b: meow<string, number>
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(results);
+
+    CHECK_EQ(toString(requireType("a")), "{read string}");
+    CHECK_EQ(toString(requireType("b")), "{ read [string]: number }");
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "type_setreadindexer_works_when_existing_readonly_indexer")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD()
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauUdtfTypeSetReadIndexerMethod, true},
+        {FFlag::LuauTypeFunctionTableIndexerIsReadOnly, true},
+        {FFlag::LuauReadOnlyIndexers, true},
+    };
+
+    CheckResult results = check(R"(
+        type function kya(tbl: type)
+            tbl:setreadindexer(types.string, types.boolean)
+            return tbl
+        end
+
+        local a: kya<{ read [number]: number }>
+        local b: kya<{ read [string]: number }>
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(results);
+
+    CHECK_EQ(toString(requireType("a")), "{ read [string]: boolean }");
+    CHECK_EQ(toString(requireType("b")), "{ read [string]: boolean }");
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "type_setreadindexer_errors_when_existing_readwrite_indexer")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD()
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauUdtfTypeSetReadIndexerMethod, true},
+        {FFlag::LuauTypeFunctionTableIndexerIsReadOnly, true},
+        {FFlag::LuauReadOnlyIndexers, true},
+    };
+
+    CheckResult results = check(R"(
+        type function nyanya(tbl: type)
+            tbl:setreadindexer(types.string, types.boolean)
+            return tbl
+        end
+
+        local a: nyanya<{ [number]: number }>
+        local b: nyanya<{ [string]: number }>
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(2, results);
+    CHECK_EQ(
+        toString(results.errors[0]),
+        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: type.setreadindexer: luau does not yet support setting a read indexer for types with an existing read+write indexer"
+    );
+    CHECK_EQ(
+        toString(results.errors[1]),
+        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: type.setreadindexer: luau does not yet support setting a read indexer for types with an existing read+write indexer"
     );
 }
 

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -3554,11 +3554,11 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "type_setreadindexer_errors_when_existing_rea
     LUAU_REQUIRE_ERROR_COUNT(2, results);
     CHECK_EQ(
         toString(results.errors[0]),
-        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: type.setreadindexer: luau does not yet support setting a read indexer for types with an existing read+write indexer"
+        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: types.setreadindexer: the table has an existing read+write indexer, which luau does not support setreadindexer for yet"
     );
     CHECK_EQ(
         toString(results.errors[1]),
-        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: type.setreadindexer: luau does not yet support setting a read indexer for types with an existing read+write indexer"
+        "'nyanya' type function errored at runtime: [string \"nyanya\"]:3: types.setreadindexer: the table has an existing read+write indexer, which luau does not support setreadindexer for yet"
     );
 }
 


### PR DESCRIPTION
previously, setreadindexer would error with `type.setreadindexer: luau does not yet support separate read/write types for indexers.`

now that read-only indexers are implemented, this PR suggests a partial implementation locked behind a new flag `LuauUdtfTypeSetReadIndexerMethod` and an old one `LuauTypeFunctionTableIndexerIsReadOnly` for serialization/deserialization. It will error if the table already has a read+write indexer, but otherwise allows the operation. Although partial implementation isn't ideal, some trivially-fixed-once-separate-read-write-indexers-are-implemented dragons are okay as this gets behavior into users' hands sooner and UDTFs are inherently forgiving towards mistakes. As usual, this PR / implementation (although small) is 100% human authored.

edit: the existing workaround people are likely to use, provided `LuauTypeFunctionTableIndexerIsReadOnly` is enabled:
```luau
type tbl_with_read_only_indexer<key, value> = { read [key]: value }

type function setreadindexer(tbl: type, index: type, value: type): type
	const new: type = tbl_with_read_only_indexer(index, value)
	const mt = tbl:metatable()
	if mt then
		new:setmetatable(mt)
	end
	for key, prop in tbl:properties() do
		const read, write = prop.read, prop.write
		if read and write and read == write then
			new:setproperty(key, read)
		else
			if read then
				new:setreadproperty(key, read)
			end
			if write then
				new:setwriteproperty(key, write)
			end
		end
	end
	return new
end
```