### PR TITLE
unused type lint

### DIFF
--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -3533,14 +3533,16 @@ private:
 
     struct Alias
     {
-        AstStat* definition = nullptr;
-        bool type_fun;
+        AstStat* declaration;
+        Location nameLocation;
+        unsigned int scopeDepth;
         bool referenced;
+        bool softReferenced;
         bool exported;
     };
 
     DenseHashMap<AstName, Alias> refs;
-    std::vector<AstName> typeFuncScopeStack;
+    std::vector<Alias*> typesEnvScopeStack;
 
     LintUnusedType()
         : refs(AstName())
@@ -3551,32 +3553,37 @@ private:
     {
         for (auto& pair : refs)
         {
-            AstStat* def = pair.second.definition;
-            if (!def)
-                continue;
-            if (pair.second.referenced)
-                continue;
-            if (pair.second.exported)
+            AstStat* declaration = pair.second.declaration;
+            if (!declaration || pair.second.referenced || pair.second.exported)
                 continue;
 
-            const char* name = pair.first.value;
+            const char* nameValue = pair.first.value;
 
-            if (name[0] == '_')
+            if (nameValue[0] == '_')
                 continue;
 
-            if (pair.second.type_fun)
-                emitWarning(
-                    *context,
-                    LintWarning::Code_TypeUnused,
-                    def->location,
-                    "Type Function '%s' is never used; prefix with '_' to silence",
-                    pair.first.value
-                );
+            const char* msg;
+            if (!declaration->is<AstStatTypeFunction>())
+                msg = "Type '%s' is never used; prefix with '_' to silence";
+            else if (!pair.second.softReferenced)
+                msg = "Type Function '%s' is never used; prefix with '_' to silence";
             else
-                emitWarning(
-                    *context, LintWarning::Code_TypeUnused, def->location, "Type '%s' is never used; prefix with '_' to silence", pair.first.value
-                );
+                msg = "Type Function '%s' is never used outside its own body; prefix with '_' to silence";
+
+            emitWarning(*context, LintWarning::Code_TypeUnused, pair.second.nameLocation, msg, nameValue);
         }
+    }
+
+    void scopePush(Alias& alias)
+    {
+        alias.scopeDepth++;
+        typesEnvScopeStack.push_back(&alias);
+    }
+    void scopePop()
+    {
+        Alias* scope = typesEnvScopeStack.back();
+        scope->scopeDepth--;
+        typesEnvScopeStack.pop_back();
     }
 
     bool visit(AstType* node) override
@@ -3591,22 +3598,22 @@ private:
     bool visit(AstStatTypeAlias* node) override
     {
         Alias& alias = refs[node->name];
-        alias.definition = node;
+        alias.declaration = node;
+        alias.nameLocation = node->nameLocation;
         alias.exported = node->exported;
 
         return true;
     }
-
     bool visit(AstStatTypeFunction* node) override
     {
         Alias& alias = refs[node->name];
-        alias.definition = node;
+        alias.declaration = node;
+        alias.nameLocation = node->nameLocation;
         alias.exported = node->exported;
-        alias.type_fun = true;
 
-        typeFuncScopeStack.push_back(node->name);
+        scopePush(alias);
         node->body->visit(this);
-        typeFuncScopeStack.pop_back();
+        scopePop();
 
         return false;
     }
@@ -3624,13 +3631,14 @@ private:
 
     bool visit(AstExprGlobal* node) override
     {
-        if (typeFuncScopeStack.empty())
+        if (typesEnvScopeStack.empty())
             return true;
 
-        if (bool typeFunRefingItself = std::find(typeFuncScopeStack.rbegin(), typeFuncScopeStack.rend(), node->name) != typeFuncScopeStack.rend())
-            return true;
-
-        refs[node->name].referenced = true;
+        Alias& alias = refs[node->name];
+        if (alias.scopeDepth > 0)
+            alias.softReferenced = true;
+        else
+            alias.referenced = true;
 
         return true;
     }

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -3533,12 +3533,13 @@ private:
 
     struct Alias
     {
-        AstStat* declaration;
+        AstStat* declaration = nullptr;
+        unsigned int scopeDepth = 0;
+        bool referenced = false;
+        bool softReferenced = false;
+        bool exported = false;
+
         Location nameLocation;
-        unsigned int scopeDepth;
-        bool referenced;
-        bool softReferenced;
-        bool exported;
     };
 
     DenseHashMap<AstName, Alias> refs;

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -1,6 +1,7 @@
 // This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
 #include "Luau/Linter.h"
 
+#include "Luau/Ast.h"
 #include "Luau/AstQuery.h"
 #include "Luau/Module.h"
 #include "Luau/Scope.h"
@@ -3514,6 +3515,127 @@ private:
     }
 };
 
+class LintUnusedType : AstVisitor
+{
+public:
+    LUAU_NOINLINE static void process(LintContext& context)
+    {
+        LintUnusedType pass;
+        pass.context = &context;
+
+        context.root->visit(&pass);
+
+        pass.report();
+    }
+
+private:
+    LintContext* context;
+
+    struct Alias
+    {
+        AstStat* definition = nullptr;
+        bool type_fun;
+        bool referenced;
+        bool exported;
+    };
+
+    DenseHashMap<AstName, Alias> refs;
+    std::vector<AstName> typeFuncScopeStack;
+
+    LintUnusedType()
+        : refs(AstName())
+    {
+    }
+
+    void report()
+    {
+        for (auto& pair : refs)
+        {
+            AstStat* def = pair.second.definition;
+            if (!def)
+                continue;
+            if (pair.second.referenced)
+                continue;
+            if (pair.second.exported)
+                continue;
+
+            const char* name = pair.first.value;
+
+            if (name[0] == '_')
+                continue;
+
+            if (pair.second.type_fun)
+                emitWarning(
+                    *context,
+                    LintWarning::Code_TypeUnused,
+                    def->location,
+                    "Type Function '%s' is never used; prefix with '_' to silence",
+                    pair.first.value
+                );
+            else
+                emitWarning(
+                    *context, LintWarning::Code_TypeUnused, def->location, "Type '%s' is never used; prefix with '_' to silence", pair.first.value
+                );
+        }
+    }
+
+    bool visit(AstType* node) override
+    {
+        return true;
+    }
+    bool visit(AstTypePack* node) override
+    {
+        return true;
+    }
+
+    bool visit(AstStatTypeAlias* node) override
+    {
+        Alias& alias = refs[node->name];
+        alias.definition = node;
+        alias.exported = node->exported;
+
+        return true;
+    }
+
+    bool visit(AstStatTypeFunction* node) override
+    {
+        Alias& alias = refs[node->name];
+        alias.definition = node;
+        alias.exported = node->exported;
+        alias.type_fun = true;
+
+        typeFuncScopeStack.push_back(node->name);
+        node->body->visit(this);
+        typeFuncScopeStack.pop_back();
+
+        return false;
+    }
+
+    bool visit(AstTypeReference* node) override
+    {
+        if (node->prefix)
+            return true;
+
+        Alias& alias = refs[node->name];
+        alias.referenced = true;
+
+        return true;
+    }
+
+    bool visit(AstExprGlobal* node) override
+    {
+        if (typeFuncScopeStack.empty())
+            return true;
+
+        if (bool typeFunRefingItself = std::find(typeFuncScopeStack.rbegin(), typeFuncScopeStack.rend(), node->name) != typeFuncScopeStack.rend())
+            return true;
+
+        refs[node->name].referenced = true;
+
+        return true;
+    }
+};
+
 std::vector<LintWarning> lint(
     AstStat* root,
     const AstNameTable& names,
@@ -3611,6 +3733,9 @@ std::vector<LintWarning> lint(
         if (hasNativeCommentDirective(hotcomments))
             LintRedundantNativeAttribute::process(context);
     }
+
+    if (context.warningEnabled(LintWarning::Code_TypeUnused))
+        LintUnusedType::process(context);
 
     std::sort(context.result.begin(), context.result.end(), WarningComparator());
 

--- a/Config/include/Luau/LinterConfig.h
+++ b/Config/include/Luau/LinterConfig.h
@@ -50,6 +50,7 @@ struct LintWarning
         Code_IntegerParsing = 27,
         Code_ComparisonPrecedence = 28,
         Code_RedundantNativeAttribute = 29,
+        Code_TypeUnused = 30,
 
         Code__Count
     };
@@ -117,6 +118,7 @@ inline constexpr const char* kWarningNames[] = {
     "IntegerParsing",
     "ComparisonPrecedence",
     "RedundantNativeAttribute",
+    "TypeUnused",
 };
 // clang-format on
 

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -883,7 +883,7 @@ return f1,f2,f3,f4
 TEST_CASE_FIXTURE(Fixture, "TypeAnnotationsShouldNotProduceWarnings")
 {
     LintResult result = lint(R"(--!strict
-type InputData = {
+export type InputData = {
     id: number,
     inputType: EnumItem,
     inputState: EnumItem,
@@ -1269,14 +1269,14 @@ TEST_CASE_FIXTURE(Fixture, "read_write_table_props")
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
 
     LintResult result = lint(R"(-- line 1
-        type A = {x: number}
-        type B = {read x: number, write x: number}
-        type C = {x: number, read x: number} -- line 4
-        type D = {x: number, write x: number}
-        type E = {read x: number, x: boolean}
-        type F = {read x: number, read x: number}
-        type G = {write x: number, x: boolean}
-        type H = {write x: number, write x: boolean}
+        export type A = {x: number}
+        export type B = {read x: number, write x: number}
+        export type C = {x: number, read x: number} -- line 4
+        export type D = {x: number, write x: number}
+        export type E = {read x: number, x: boolean}
+        export type F = {read x: number, read x: number}
+        export type G = {write x: number, x: boolean}
+        export type H = {write x: number, write x: boolean}
     )");
 
     REQUIRE(6 == result.warnings.size());
@@ -2570,6 +2570,163 @@ a<<"hi">>("hi")
 )");
 
     REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_referenced_type_alias")
+{
+    LintResult result = lint(R"(
+type Mrrp = {}
+type Meow = Mrrp
+
+return function(): Meow
+    return {}
+end
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_exported_type_alias")
+{
+    LintResult result = lint(R"(
+export type Mrrp = {}
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_referenced_type_fun")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type function Kya()
+    return types.any
+end
+
+return function(): Kya<>
+    return {}
+end
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_exported_type_fun")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+export type function Kya()
+    return types.any
+end
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_type_alias_referenced_type_from_type_fun_body")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type Mrrp = {}
+type Meow = Mrrp
+
+type function Kya()
+    return Meow
+end
+
+return function(): Kya<>
+    return {}
+end
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_referenced_type_fun_from_other_type_fun")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type function Kya()
+    return types.any
+end
+type function Purr()
+    return Kya()
+end
+return ... :: Purr<>
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_type_alias_alone")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type Mrrp = {}
+)");
+
+    REQUIRE(1 == result.warnings.size());
+    CHECK_EQ(result.warnings[0].text, "Type 'Mrrp' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(1, 14)));
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_type_alias_reference_chain_unreferenced")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type Mrrp = {}
+type Meow = Mrrp
+)");
+
+    REQUIRE(1 == result.warnings.size());
+    CHECK_EQ(result.warnings[0].text, "Type 'Meow' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[0].location, Location(Position(2, 0), Position(2, 16)));
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_unreferenced_type_fun")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type function Kya()
+    return types.any
+end
+)");
+
+    REQUIRE(1 == result.warnings.size());
+    CHECK_EQ(result.warnings[0].text, "Type Function 'Kya' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(3, 3)));
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_recursive_type_fun")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type function Kya()
+    return Kya()
+end
+)");
+
+    REQUIRE(1 == result.warnings.size());
+    CHECK_EQ(result.warnings[0].text, "Type Function 'Kya' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(3, 3)));
+}
+
+TEST_CASE_FIXTURE(Fixture, "unused_type_unrelated_global_reference")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    LintResult result = lint(R"(
+type Purr = number
+type function Hiss()
+    return types.any
+end
+return Purr or Hiss
+)");
+
+    REQUIRE(2 == result.warnings.size());
+    CHECK_EQ(result.warnings[0].text, "Type 'Purr' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(1, 18)));
+    CHECK_EQ(result.warnings[1].text, "Type Function 'Hiss' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[1].location, Location(Position(2, 0), Position(4, 3)));
 }
 
 TEST_SUITE_END();

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -2667,7 +2667,7 @@ type Mrrp = {}
 
     REQUIRE(1 == result.warnings.size());
     CHECK_EQ(result.warnings[0].text, "Type 'Mrrp' is never used; prefix with '_' to silence");
-    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(1, 14)));
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 5), Position(1, 9)));
 }
 
 TEST_CASE_FIXTURE(Fixture, "unused_type_type_alias_reference_chain_unreferenced")
@@ -2680,7 +2680,7 @@ type Meow = Mrrp
 
     REQUIRE(1 == result.warnings.size());
     CHECK_EQ(result.warnings[0].text, "Type 'Meow' is never used; prefix with '_' to silence");
-    CHECK_EQ(result.warnings[0].location, Location(Position(2, 0), Position(2, 16)));
+    CHECK_EQ(result.warnings[0].location, Location(Position(2, 5), Position(2, 9)));
 }
 
 TEST_CASE_FIXTURE(Fixture, "unused_type_unreferenced_type_fun")
@@ -2694,7 +2694,7 @@ end
 
     REQUIRE(1 == result.warnings.size());
     CHECK_EQ(result.warnings[0].text, "Type Function 'Kya' is never used; prefix with '_' to silence");
-    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(3, 3)));
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 14), Position(1, 17)));
 }
 
 TEST_CASE_FIXTURE(Fixture, "unused_type_recursive_type_fun")
@@ -2707,8 +2707,8 @@ end
 )");
 
     REQUIRE(1 == result.warnings.size());
-    CHECK_EQ(result.warnings[0].text, "Type Function 'Kya' is never used; prefix with '_' to silence");
-    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(3, 3)));
+    CHECK_EQ(result.warnings[0].text, "Type Function 'Kya' is never used outside its own body; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 14), Position(1, 17)));
 }
 
 TEST_CASE_FIXTURE(Fixture, "unused_type_unrelated_global_reference")
@@ -2724,9 +2724,9 @@ return Purr or Hiss
 
     REQUIRE(2 == result.warnings.size());
     CHECK_EQ(result.warnings[0].text, "Type 'Purr' is never used; prefix with '_' to silence");
-    CHECK_EQ(result.warnings[0].location, Location(Position(1, 0), Position(1, 18)));
+    CHECK_EQ(result.warnings[0].location, Location(Position(1, 5), Position(1, 9)));
     CHECK_EQ(result.warnings[1].text, "Type Function 'Hiss' is never used; prefix with '_' to silence");
-    CHECK_EQ(result.warnings[1].location, Location(Position(2, 0), Position(4, 3)));
+    CHECK_EQ(result.warnings[1].location, Location(Position(2, 14), Position(2, 18)));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
unused type alias / type function lint pass. does not trigger on `export`, references to type functions from within that type function's body don't count. tested failure cases pretty extensively, pr/code/tests are 100% human authored.

silencing path is to prefix the type with `_` for now. Although you cannot declare multiple type aliases with the name `_`, unused types like that are niche, and users can always `--!nolint TypeUnused`.

- closes #1665 