### PR TITLE
make locals named `types` not shadow the global in the type function runtime

### DIFF
--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -781,6 +781,9 @@ private:
                 ; // there are many builtins with common names like 'table'; some of them are deprecated as well
             else if (global->firstRef)
             {
+                // accounting for type functions explicitly in this lint would be better but ya can't beat a 1 line fix
+                if (local->name == "types")
+                    return;
                 emitWarning(
                     *context,
                     LintWarning::Code_LocalShadow,

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -2572,4 +2572,19 @@ a<<"hi">>("hi")
     REQUIRE(0 == result.warnings.size());
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "localshadow_global_types_library_fix_1564")
+{
+    LintResult result = lint(R"(
+type function test()
+    return types.any
+end
+
+local types = 123
+
+return types :: test<>
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
- closes #1564 