### PR TITLE
improve performance of table.maxn

### DIFF
--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -55,12 +55,6 @@ static int maxn(lua_State* L)
 
     LuaTable* t = hvalue(L->base);
 
-    for (int i = 0; i < t->sizearray; i++)
-    {
-        if (!ttisnil(&t->array[i]))
-            max = i + 1;
-    }
-
     for (int i = 0; i < sizenode(t); i++)
     {
         LuaNode* n = gnode(t, i);
@@ -71,6 +65,16 @@ static int maxn(lua_State* L)
 
             if (v > max)
                 max = v;
+        }
+    }
+
+    for (int i = t->sizearray; i > max;)
+    {
+        i--;
+        if (!ttisnil(&t->array[i]))
+        {
+            max = i + 1;
+            break;
         }
     }
 

--- a/tests/conformance/tables.luau
+++ b/tests/conformance/tables.luau
@@ -311,6 +311,12 @@ assert(table.maxn{["1000"] = true} == 0)
 assert(table.maxn{["1000"] = true, [24.5] = 3} == 24.5)
 assert(table.maxn{[1000] = true} == 1000)
 assert(table.maxn{[10] = true, [100*math.pi] = print} == 100*math.pi)
+assert(table.maxn{[1] = true, [2] = true, [1.1] = true} == 2)
+assert(table.maxn{[1] = true, [2] = nil, [1.1] = true} == 1.1)
+assert(table.maxn{[1] = true, [0.9999] = true} == 1)
+assert(table.maxn{[0] = 123, [0.1] = 1234} == 0.1)
+assert(table.maxn{[1] = true, [math.huge] = true} == math.huge)
+assert(table.maxn{[1] = true, [-math.huge] = true} == 1)
 a = {[10] = 1, [20] = 2}
 a[20] = nil
 assert(table.maxn(a) == 10)


### PR DESCRIPTION
i noticed `table.maxn` iterates the entirety of both the array and hash portions of a table. i've changed this to first iterate for the highest value in the hash portion, and then iterate the array portion in reverse, exit when you first encounter a non-nil. it should be a strict performance improvement. I've also added extra conformance tests around `table.maxn` with keys of `math.huge`, `-math.huge`, etc...