### PR TITLE
Support 4-wide vector type definitions via Frontend setting

### DIFF
--- a/Analysis/include/Luau/BuiltinDefinitions.h
+++ b/Analysis/include/Luau/BuiltinDefinitions.h
@@ -80,7 +80,7 @@ void attachMagicFunction(TypeId ty, std::shared_ptr<MagicFunction> magic);
 Property makeProperty(TypeId ty, std::optional<std::string> documentationSymbol = std::nullopt);
 void assignPropDocumentationSymbols(TableType::Props& props, const std::string& baseName);
 
-std::string getBuiltinDefinitionSource();
+std::string getBuiltinDefinitionSource(VectorSize vectorSize = VectorSize::Three);
 std::string getTypeFunctionDefinitionSource();
 
 void addGlobalBinding(GlobalTypes& globals, const std::string& name, TypeId ty, const std::string& packageName);

--- a/Analysis/include/Luau/Frontend.h
+++ b/Analysis/include/Luau/Frontend.h
@@ -182,6 +182,10 @@ struct Frontend
     SolverMode getLuauSolverMode() const;
     // The default value assuming there is no workspace setup yet
     std::atomic<SolverMode> useNewLuauSolver;
+
+    void setVectorSize(VectorSize size);
+    VectorSize getVectorSize() const;
+    std::atomic<VectorSize> vectorSize;
     // Parse module graph and prepare SourceNode/SourceModule data, including required dependencies without running typechecking
     void parse(const ModuleName& name);
     void parseModules(const std::vector<ModuleName>& name);

--- a/Analysis/include/Luau/Type.h
+++ b/Analysis/include/Luau/Type.h
@@ -46,6 +46,13 @@ enum struct SolverMode
     New
 };
 
+// Number of components in the 'vector' type, matching the VM's LUA_VECTOR_SIZE (which is always 3 or 4)
+enum struct VectorSize
+{
+    Three,
+    Four
+};
+
 /**
  * There are three kinds of type variables:
  * - `Free` variables are metavariables, which stand for unconstrained types.

--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -358,7 +358,7 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
 
 
     LoadDefinitionFileResult loadResult = frontend.loadDefinitionFile(
-        globals, globals.globalScope, getBuiltinDefinitionSource(), "@luau", /* captureComments */ false, typeCheckForAutocomplete
+        globals, globals.globalScope, getBuiltinDefinitionSource(frontend.getVectorSize()), "@luau", /* captureComments */ false, typeCheckForAutocomplete
     );
     LUAU_ASSERT(loadResult.success);
 

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -309,7 +309,9 @@ declare buffer: {
 
 )BUILTIN_SRC";
 
-static const char* const kBuiltinDefinitionVectorSrc = R"BUILTIN_SRC(
+// The vector library's shape depends on the vector width: 4-wide vectors expose a 'w' component and take a
+// fourth argument in 'create'. Both headers are compiled in and selected at runtime; the method list is shared.
+static const char* const kBuiltinDefinitionVector3HeaderSrc = R"BUILTIN_SRC(
 
 -- While vector would have been better represented as a built-in primitive type, type solver extern type handling covers most of the properties
 declare extern type vector with
@@ -319,7 +321,22 @@ declare extern type vector with
 end
 
 declare vector: {
-    create: @checked (x: number, y: number, z: number?) -> vector,
+    create: @checked (x: number, y: number, z: number?) -> vector,)BUILTIN_SRC";
+
+static const char* const kBuiltinDefinitionVector4HeaderSrc = R"BUILTIN_SRC(
+
+-- While vector would have been better represented as a built-in primitive type, type solver extern type handling covers most of the properties
+declare extern type vector with
+    read x: number
+    read y: number
+    read z: number
+    read w: number
+end
+
+declare vector: {
+    create: @checked (x: number, y: number, z: number?, w: number?) -> vector,)BUILTIN_SRC";
+
+static const char* const kBuiltinDefinitionVectorSrc = R"BUILTIN_SRC(
     magnitude: @checked (vec: vector) -> number,
     normalize: @checked (vec: vector) -> vector,
     cross: @checked (vec1: vector, vec2: vector) -> vector,
@@ -395,7 +412,7 @@ declare class: {
 }
 )CLASS_SRC";
 
-std::string getBuiltinDefinitionSource()
+std::string getBuiltinDefinitionSource(VectorSize vectorSize)
 {
     std::string result = kBuiltinDefinitionBaseSrc;
 
@@ -411,6 +428,7 @@ std::string getBuiltinDefinitionSource()
     else
         result += kBuiltinDefinitionBufferSrc_NOINTEGER;
 
+    result += vectorSize == VectorSize::Four ? kBuiltinDefinitionVector4HeaderSrc : kBuiltinDefinitionVector3HeaderSrc;
     result += kBuiltinDefinitionVectorSrc;
 
     if (FFlag::LuauIntegerType2 && FFlag::LuauIntegerLibrary)

--- a/Analysis/src/Frontend.cpp
+++ b/Analysis/src/Frontend.cpp
@@ -446,6 +446,7 @@ static TypeCheckLimits makeTypeCheckLimits(const FrontendOptions& options)
 
 Frontend::Frontend(SolverMode mode, FileResolver* fileResolver, ConfigResolver* configResolver, FrontendOptions options)
     : useNewLuauSolver(mode)
+    , vectorSize(VectorSize::Three)
     , builtinTypes(NotNull{&builtinTypes_})
     , fileResolver(fileResolver)
     , moduleResolver(this)
@@ -459,6 +460,7 @@ Frontend::Frontend(SolverMode mode, FileResolver* fileResolver, ConfigResolver* 
 
 Frontend::Frontend(FileResolver* fileResolver, ConfigResolver* configResolver, const FrontendOptions& options)
     : useNewLuauSolver(FFlag::LuauSolverV2 ? SolverMode::New : SolverMode::Old)
+    , vectorSize(VectorSize::Three)
     , builtinTypes(NotNull{&builtinTypes_})
     , fileResolver(fileResolver)
     , moduleResolver(this)
@@ -478,6 +480,16 @@ void Frontend::setLuauSolverMode(SolverMode mode)
 SolverMode Frontend::getLuauSolverMode() const
 {
     return useNewLuauSolver.load();
+}
+
+void Frontend::setVectorSize(VectorSize size)
+{
+    vectorSize.store(size);
+}
+
+VectorSize Frontend::getVectorSize() const
+{
+    return vectorSize.load();
 }
 
 void Frontend::parse(const ModuleName& name)

--- a/CLI/src/Analyze.cpp
+++ b/CLI/src/Analyze.cpp
@@ -471,6 +471,7 @@ int main(int argc, char** argv)
         };
     }
 
+    frontend.setVectorSize(LUA_VECTOR_SIZE == 4 ? Luau::VectorSize::Four : Luau::VectorSize::Three);
     Luau::registerBuiltinGlobals(frontend, frontend.globals);
     Luau::freeze(frontend.globals.globalTypes);
 

--- a/CLI/src/Web.cpp
+++ b/CLI/src/Web.cpp
@@ -152,6 +152,7 @@ extern "C" const char* checkScript(const char* source, int useNewSolver)
 
         Luau::Frontend frontend(&fileResolver, &configResolver, options);
         frontend.setLuauSolverMode(useNewSolver ? Luau::SolverMode::New : Luau::SolverMode::Old);
+        frontend.setVectorSize(LUA_VECTOR_SIZE == 4 ? Luau::VectorSize::Four : Luau::VectorSize::Three);
         // Add Luau builtins
         Luau::unfreeze(frontend.globals.globalTypes);
         Luau::registerBuiltinGlobals(frontend, frontend.globals);


### PR DESCRIPTION
### Summary

The embedded builtin type definitions describe `vector` as 3-wide unconditionally, so under a VM built with `LUA_VECTOR_SIZE == 4` the analyzer is wrong: it misses the `w` component and rejects the fourth `create` argument. This PR makes the vector width a runtime choice on the `Frontend` so a single Analysis build can serve either 3 or 4 wide vectors.

### Changes

A `VectorSize` enum (`Three` / `Four`, so only valid widths are representable) becomes a setting on the `Frontend`, mirroring `SolverMode`: `getVectorSize()` / `setVectorSize()` over an atomic member, defaults to `Three` to preserve existing behavior. Both the 3-wide and 4-wide vector definitions are compiled in and chosen at runtime when builtins are registered; the shared method list is a single definition. The width is supplied by the embedder, so the Analysis library does not depend on the VM's configuration header.

The bundled CLIs set `VectorSize` from the LUA_VECTOR_SIZE they were built with; other embedders (e.g. an LSP) may set it from their own config.

The default (`VectorSize::Three`) definition source is byte-for-byte identical to before, so existing behavior is unchanged.
The `VectorSize::Four` source adds exactly the `read w: number` component and the `w: number?` argument to `create`.