### PR TITLE
Fix typo in LUA_CALLINFO_OPYIELD comment

### DIFF
--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -75,7 +75,7 @@ typedef struct CallInfo
 #define LUA_CALLINFO_RETURN (1 << 0) // should the interpreter return after returning from this callinfo? first frame must have this set
 #define LUA_CALLINFO_HANDLE (1 << 1) // should the error thrown during execution get handled by continuation from this callinfo? func must be C
 #define LUA_CALLINFO_NATIVE (1 << 2) // should this function be executed using execution callback for native code
-#define LUA_CALLINFO_OPYIELD (1 << 3) // call frame has yielded on a non-call opcode and requires luaV_finishop
+#define LUA_CALLINFO_OPYIELD (1 << 3) // call frame has yielded on a non-call opcode and requires luau_finishop
 
 #define curr_func(L) (clvalue(L->ci->func))
 #define ci_func(ci) (clvalue((ci)->func))


### PR DESCRIPTION
Replaces luaV_finishop with luau_finishop in the comment for LUA_CALLINFO_OPYIELD. luaV_finishop doesn't exist in the repo (looks like an old Lua 5.x name).