### PR TITLE
Pretty-print indexer access

### DIFF
--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -12,6 +12,7 @@
 
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauExportValueSyntax)
+LUAU_FASTFLAGVARIABLE(LuauPrettyPrintVisualizeIndexerAccess)
 
 namespace
 {
@@ -1885,6 +1886,16 @@ struct Printer
             {
                 if (a->props.size == 0 && indexType && indexType->name == "number")
                 {
+                    if (AstTableAccess access = a->indexer->access;
+                        FFlag::LuauPrettyPrintVisualizeIndexerAccess && access != AstTableAccess::ReadWrite
+                    )
+                    {
+                        if (const std::optional<Location>& accessLocation = a->indexer->accessLocation)
+                            advance(accessLocation->begin);
+
+                        writer.keyword(access == AstTableAccess::Read ? "read" : "write");
+                    }
+
                     visualizeTypeAnnotation(*a->indexer->resultType);
                 }
                 else
@@ -1905,6 +1916,20 @@ struct Printer
                     if (a->indexer)
                     {
                         comma();
+
+                        if (FFlag::LuauPrettyPrintVisualizeIndexerAccess)
+                        {
+                            if (AstTableAccess access = a->indexer->access; access != AstTableAccess::ReadWrite)
+                            {
+                                if (const std::optional<Location>& accessLocation = a->indexer->accessLocation)
+                                    advance(accessLocation->begin);
+
+                                writer.keyword(access == AstTableAccess::Read ? "read" : "write");
+                            }
+
+                            advance(a->indexer->location.begin);
+                        }
+
                         writer.symbol("[");
                         visualizeTypeAnnotation(*a->indexer->indexType);
                         writer.symbol("]");

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -11,6 +11,7 @@
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
+LUAU_FASTFLAG(LuauPrettyPrintVisualizeReadOnlyIndexers)
 
 using namespace Luau;
 
@@ -2630,6 +2631,16 @@ TEST_CASE("pretty_print_incomplete_attr_args")
     function oldApi()
     end
     )=";
+
+    CHECK_EQ(code, prettyPrint(code, {}, true, true).code);
+}
+
+TEST_CASE("pretty_print_readonly_indexer")
+{
+    std::string code = R"(
+        local _t: { read number } = {}
+        local _u: { read [string]: boolean }
+    )";
 
     CHECK_EQ(code, prettyPrint(code, {}, true, true).code);
 }

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -11,7 +11,7 @@
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
-LUAU_FASTFLAG(LuauPrettyPrintVisualizeReadOnlyIndexers)
+LUAU_FASTFLAG(LuauPrettyPrintVisualizeIndexerAccess)
 
 using namespace Luau;
 
@@ -2637,6 +2637,8 @@ TEST_CASE("pretty_print_incomplete_attr_args")
 
 TEST_CASE("pretty_print_readonly_indexer")
 {
+    ScopedFastFlag visualizeIndexerAccess{FFlag::LuauPrettyPrintVisualizeIndexerAccess, true};
+
     std::string code = R"(
         local _t: { read number } = {}
         local _u: { read [string]: boolean }


### PR DESCRIPTION
Flagged behind `LuauPrettyPrintVisualizeIndexerAccess`. Adds 1 test.

Also fixes bug where indexer start location was not respected for non-`number` indexers.