### PR TITLE
Fix read-only indexer access mismatch errors

### DIFF
--- a/Analysis/include/Luau/Subtyping.h
+++ b/Analysis/include/Luau/Subtyping.h
@@ -40,11 +40,11 @@ struct SubtypingReasoning
     // The path, relative to the _root supertype_, where subtyping failed.
     Path superPath;
     SubtypingVariance variance = SubtypingVariance::Covariant;
-    // Set when the failure is due to a property modifier mismatch (e.g. the
+    // Set when the failure is due to a property or indexer modifier mismatch (e.g. the
     // sub property is read-only or write-only but the super property requires
     // read-write). In this case the leaf types at the path ends are the same,
     // so a plain "X is not a subtype of X" message would be misleading.
-    bool isPropertyModifierViolation = false;
+    bool isAccessModifierViolation = false;
 
     bool operator==(const SubtypingReasoning& other) const;
 };
@@ -142,7 +142,7 @@ struct SubtypingResult
     SubtypingResult& withSuperPath(TypePath::Path path);
     SubtypingResult& withErrors(ErrorVec& err);
     SubtypingResult& withError(TypeError err);
-    SubtypingResult& withPropertyModifierViolation();
+    SubtypingResult& withAccessModifierViolation();
 
     SubtypingResult& withAssumedConstraint(ConstraintV constraint);
 

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAGVARIABLE(LuauDropUnionSubtypeReasoning)
 LUAU_FASTFLAGVARIABLE(LuauDontBindOptionalGenericToNil)
 LUAU_FASTFLAGVARIABLE(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauIndexerModifierMismatchErrors)
 
 namespace Luau
 {
@@ -37,13 +38,13 @@ namespace Luau
 bool SubtypingReasoning::operator==(const SubtypingReasoning& other) const
 {
     return subPath == other.subPath && superPath == other.superPath && variance == other.variance &&
-           isPropertyModifierViolation == other.isPropertyModifierViolation;
+           isAccessModifierViolation == other.isAccessModifierViolation;
 }
 
 size_t SubtypingReasoningHash::operator()(const SubtypingReasoning& r) const
 {
     return TypePath::PathHash()(r.subPath) ^ (TypePath::PathHash()(r.superPath) << 1) ^ (static_cast<size_t>(r.variance) << 1) ^
-           (static_cast<size_t>(r.isPropertyModifierViolation) << 2);
+           (static_cast<size_t>(r.isAccessModifierViolation) << 2);
 }
 
 MappedGenericEnvironment::MappedGenericFrame::MappedGenericFrame(
@@ -365,10 +366,10 @@ SubtypingResult& SubtypingResult::withError(TypeError err)
     return *this;
 }
 
-SubtypingResult& SubtypingResult::withPropertyModifierViolation()
+SubtypingResult& SubtypingResult::withAccessModifierViolation()
 {
     for (auto& r : reasoning)
-        r.isPropertyModifierViolation = true;
+        r.isAccessModifierViolation = true;
     return *this;
 }
 
@@ -2503,7 +2504,7 @@ SubtypingResult Subtyping::isCovariantWith(
 )
 {
     SubtypingResult result{false};
-    if (subIndexer.isReadOnly && !superIndexer.isReadOnly)
+    if (!FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
         return result.withBothComponent(TypePath::TypeField::IndexResult);
 
     result = isInvariantWith(env, subIndexer.indexType, superIndexer.indexType, scope).withBothComponent(TypePath::TypeField::IndexLookup);
@@ -2515,6 +2516,9 @@ SubtypingResult Subtyping::isCovariantWith(
     else
         result.andAlso(isInvariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
                            .withBothComponent(TypePath::TypeField::IndexResult));
+
+    if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
+        result.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation();
 
     return result;
 }
@@ -2549,14 +2553,14 @@ SubtypingResult Subtyping::isCovariantWith(
             if (subProp.isReadOnly())
             {
                 if (FFlag::LuauPropertyModifierMismatchErrors)
-                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::read(name)).withPropertyModifierViolation());
+                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::read(name)).withAccessModifierViolation());
                 else
                     res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::read(name)));
             }
             else if (subProp.isWriteOnly())
             {
                 if (FFlag::LuauPropertyModifierMismatchErrors)
-                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::write(name)).withPropertyModifierViolation());
+                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::write(name)).withAccessModifierViolation());
                 else
                     res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::write(name)));
             }

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -2518,7 +2518,7 @@ SubtypingResult Subtyping::isCovariantWith(
                            .withBothComponent(TypePath::TypeField::IndexResult));
 
     if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
-        result.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation();
+        result.andAlso(SubtypingResult{false}.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation());
 
     return result;
 }

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -36,6 +36,7 @@ LUAU_FASTFLAG(DebugLuauMagicTypes)
 
 LUAU_FASTFLAGVARIABLE(LuauCheckFunctionStatementTypes)
 LUAU_FASTFLAGVARIABLE(LuauPropertyModifierMismatchErrors)
+LUAU_FASTFLAGVARIABLE(LuauIndexerModifierMismatchErrors)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
 
@@ -3072,28 +3073,56 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
 
         std::stringstream reason;
 
-        if (FFlag::LuauPropertyModifierMismatchErrors && reasoning.isPropertyModifierViolation)
+        if ((FFlag::LuauPropertyModifierMismatchErrors || FFlag::LuauIndexerModifierMismatchErrors) && reasoning.isAccessModifierViolation)
         {
-            // The leaf types at the end of the paths are the same type, so a
-            // plain "X is not a subtype of X" message would be misleading.
-            // Instead, explain that the mismatch is about the property modifier.
-            std::string propName = "a property";
-            bool isReadOnly = true;
-            auto last = reasoning.subPath.last();
-            LUAU_ASSERT(last && get_if<TypePath::Property>(&*last));
-            if (last)
+            if (FFlag::LuauPropertyModifierMismatchErrors && FFlag::LuauIndexerModifierMismatchErrors)
             {
-                if (auto* prop = get_if<TypePath::Property>(&*last))
-                {
-                    propName = "`" + prop->name + "`";
-                    isReadOnly = prop->isRead;
-                }
-            }
+                // The leaf types at the end of the paths are the same type, so a
+                // plain "X is not a subtype of X" message would be misleading.
+                // Instead, explain that the mismatch is about the access modifier.
+                auto last = reasoning.subPath.last();
+                bool isReadOnly = true;
+                std::string path = "something";
 
-            if (isReadOnly)
-                reason << propName << " is a read-only property in the latter type, but the former type requires a read-write property";
+                if (last)
+                {
+                    if (auto* prop = get_if<TypePath::Property>(&*last))
+                    {
+                        path = "`" + prop->name + "`";
+                        isReadOnly = prop->isRead;
+                    }
+                    else if (auto* field = get_if<TypePath::TypeField>(&*last); field && *field == TypePath::TypeField::IndexResult)
+                        path = "the indexer";
+                }
+
+                if (isReadOnly)
+                    reason << path << " is read-only in the latter type, but the former type requires it to be read-write";
+                else
+                    reason << path << " is write-only in the latter type, but the former type requires it to be read-write";
+            }
             else
-                reason << propName << " is a write-only property in the latter type, but the former type requires a read-write property";
+            {
+                // The leaf types at the end of the paths are the same type, so a
+                // plain "X is not a subtype of X" message would be misleading.
+                // Instead, explain that the mismatch is about the property modifier.
+                std::string propName = "a property";
+                bool isReadOnly = true;
+                auto last = reasoning.subPath.last();
+                LUAU_ASSERT(last && get_if<TypePath::Property>(&*last));
+                if (last)
+                {
+                    if (auto* prop = get_if<TypePath::Property>(&*last))
+                    {
+                        propName = "`" + prop->name + "`";
+                        isReadOnly = prop->isRead;
+                    }
+                }
+
+                if (isReadOnly)
+                    reason << propName << " is a read-only property in the latter type, but the former type requires a read-write property";
+                else
+                    reason << propName << " is a write-only property in the latter type, but the former type requires a read-write property";
+            }
         }
         else if (reasoning.subPath == reasoning.superPath)
             reason << toStringHuman(reasoning.subPath) << "`" << subLeafAsString << "` in the latter type and `" << superLeafAsString

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -3100,7 +3100,7 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
                 else
                     reason << path << " is write-only in the latter type, but the former type requires it to be read-write";
             }
-            else
+            else if (FFlag::LuauPropertyModifierMismatchErrors)
             {
                 // The leaf types at the end of the paths are the same type, so a
                 // plain "X is not a subtype of X" message would be misleading.

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -29,6 +29,7 @@ LUAU_FASTFLAG(LuauPropertyModifierMismatchErrors)
 LUAU_FASTFLAG(LuauRemoveConstraintSolverEmplace)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
 LUAU_FASTFLAG(LuauAlwaysIntersectTablesWithTables)
+LUAU_FASTFLAG(LuauIndexerModifierMismatchErrors)
 
 TEST_SUITE_BEGIN("TableTests");
 
@@ -4498,7 +4499,10 @@ TEST_CASE_FIXTURE(Fixture, "write_to_unusually_named_read_only_property")
 TEST_CASE_FIXTURE(Fixture, "read_only_property_with_type_mismatch_reports_both_errors")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
-    ScopedFastFlag sff{FFlag::LuauPropertyModifierMismatchErrors, true};
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
 
     // When a property is both read-only AND has a type mismatch, both issues are reported
     // independently so the user knows they need to fix both.
@@ -4512,13 +4516,16 @@ TEST_CASE_FIXTURE(Fixture, "read_only_property_with_type_mismatch_reports_both_e
 
     const std::string msg = toString(result.errors[0]);
     CHECK(msg.find("accessing `woof` results in `string` in the latter type and `number` in the former type") != std::string::npos);
-    CHECK(msg.find("`woof` is a read-only property in the latter type, but the former type requires a read-write property") != std::string::npos);
+    CHECK(msg.find("`woof` is read-only in the latter type, but the former type requires it to be read-write") != std::string::npos);
 }
 
 TEST_CASE_FIXTURE(Fixture, "read_only_property_subtype_mismatch_error_message")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
-    ScopedFastFlag sff{FFlag::LuauPropertyModifierMismatchErrors, true};
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
 
     CheckResult result = check(R"(
         local function f(t: { read woof: number }): { woof: number }
@@ -4533,14 +4540,17 @@ TEST_CASE_FIXTURE(Fixture, "read_only_property_subtype_mismatch_error_message")
         "\t'{ woof: number }'\n"
         "but got\n"
         "\t'{ read woof: number }'; \n"
-        "`woof` is a read-only property in the latter type, but the former type requires a read-write property" == toString(result.errors[0])
+        "`woof` is read-only in the latter type, but the former type requires it to be read-write" == toString(result.errors[0])
     );
 }
 
 TEST_CASE_FIXTURE(Fixture, "write_only_property_subtype_mismatch_error_message")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
-    ScopedFastFlag sff{FFlag::LuauPropertyModifierMismatchErrors, true};
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
 
     CheckResult result = check(R"(
         local function f(t: { write woof: number }): { woof: number }
@@ -4555,7 +4565,7 @@ TEST_CASE_FIXTURE(Fixture, "write_only_property_subtype_mismatch_error_message")
         "\t'{ woof: number }'\n"
         "but got\n"
         "\t'{ write woof: number }'; \n"
-        "`woof` is a write-only property in the latter type, but the former type requires a read-write property" == toString(result.errors[0])
+        "`woof` is write-only in the latter type, but the former type requires it to be read-write" == toString(result.errors[0])
     );
 }
 
@@ -7346,6 +7356,32 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "normalization_always_intersects_table")
             end
         end
     )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_mismatch_error")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    ScopedFastFlag _[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
+
+    CheckResult result = check(R"(
+        local function needBoth(_t: { string })
+        end
+
+        local read: { read number } = {}
+        needBoth(read)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK_EQ(toString(result.errors[0]), "Expected this to be"
+        "\n\t'{ x: string }'"
+        "\nbut got"
+        "\n\t'{ read x: number }'; "
+        "\nthis is because "
+        "\n\t* `x` is read-only in the latter type, but the former type requires it to be read-write"
+        "\n\t* accessing `x` results in `number` in the latter type and `string` in the former type, and `number` is not a subtype of `string`");
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -7367,6 +7367,27 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_mismatch_error")
     };
 
     CheckResult result = check(R"(
+        local function needBoth(_t: { number })
+        end
+
+        local read: { read number } = {}
+        needBoth(read)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK_EQ(toString(result.errors[0]), "Expected this to be '{number}', but got '{read number}'; "
+        "\nthe indexer is read-only in the latter type, but the former type requires it to be read-write");
+}
+
+TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_and_type_mismatch_error")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    ScopedFastFlag _[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
+
+    CheckResult result = check(R"(
         local function needBoth(_t: { string })
         end
 
@@ -7375,13 +7396,10 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_mismatch_error")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK_EQ(toString(result.errors[0]), "Expected this to be"
-        "\n\t'{ x: string }'"
-        "\nbut got"
-        "\n\t'{ read x: number }'; "
+    CHECK_EQ(toString(result.errors[0]), "Expected this to be '{string}', but got '{read number}'; "
         "\nthis is because "
-        "\n\t* `x` is read-only in the latter type, but the former type requires it to be read-write"
-        "\n\t* accessing `x` results in `number` in the latter type and `string` in the former type, and `number` is not a subtype of `string`");
+        "\n\t * the indexer is read-only in the latter type, but the former type requires it to be read-write"
+        "\n\t * the result of indexing is `number` in the latter type and `string` in the former type, and `number` is not exactly `string`");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
The error reasoning for:

```luau
local x: { read string } = {}
local y: { string } = x
```

, will be:

```
the indexer is read-only in the latter type, but the former type requires it to be read-write
```

instead of:

```
the result of indexing is `string` in the latter type and `string` in the former type, and `string` is not a subtype of `string`
```

Flagged behind `LuauIndexerModifierMismatchErrors` (new) and `LuauPropertyModifierMismatchErrors` (existing). Adds 2 tests.

Additionally, when both are enabled, the property modifier mismatch errors are also slightly reworded, from:

```
`x` is a read-only property in the latter type, but the former type requires a read-write property
```

, to:

```
`x` is read-only in the latter type, but the former type requires it to be read-write
```

, done so that some code can be shared.