### PR TITLE
Avoid redundant MOVEs within expressions in concatenation chains

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -33,6 +33,7 @@ LUAU_FASTFLAGVARIABLE(LuauCompileIifeInline)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAGVARIABLE(LuauCompileStringInterpTargetTop)
+LUAU_FASTFLAGVARIABLE(LuauCompileConcatTargetTop)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAGVARIABLE(LuauEmitCallFeedback)
 LUAU_FASTFLAGVARIABLE(LuauOptimizeExportTable)
@@ -2275,7 +2276,10 @@ struct Compiler
             uint8_t regs = allocReg(expr, unsigned(args.size()));
 
             for (size_t i = 0; i < args.size(); ++i)
-                compileExprTemp(args[i], uint8_t(regs + i));
+                if (FFlag::LuauCompileConcatTargetTop)
+                    compileExprTempTop(args[i], uint8_t(regs + i));
+                else
+                    compileExprTemp(args[i], uint8_t(regs + i));
 
             bytecode.emitABC(LOP_CONCAT, target, regs, uint8_t(regs + args.size() - 1));
         }
@@ -4384,7 +4388,10 @@ struct Compiler
             compileLValueUse(var, regs, /* set= */ false, stat->var);
 
             for (size_t i = 0; i < args.size(); ++i)
-                compileExprTemp(args[i], uint8_t(regs + 1 + i));
+                if (FFlag::LuauCompileConcatTargetTop)
+                    compileExprTempTop(args[i], uint8_t(regs + 1 + i));
+                else
+                    compileExprTemp(args[i], uint8_t(regs + 1 + i));
 
             bytecode.emitABC(LOP_CONCAT, target, regs, uint8_t(regs + args.size()));
         }

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -29,6 +29,7 @@ LUAU_FASTFLAG(LuauCompileIifeInline)
 LUAU_FASTFLAG(LuauIntegerBufferFastcalls)
 LUAU_FASTFLAG(LuauCompileEmitVectorDouble)
 LUAU_FASTFLAG(LuauCompileStringInterpTargetTop)
+LUAU_FASTFLAG(LuauCompileConcatTargetTop)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(LuauEmitCallFeedback)
@@ -490,14 +491,38 @@ CONCAT R3 R4 R6
 RETURN R3 1
 )");
 
+    ScopedFastFlag luauCompileConcatTargetTop{FFlag::LuauCompileConcatTargetTop, true};
+
     CHECK_EQ("\n" + compileFunction0("local a, b, c = ...; return (a .. b) .. c"), R"(
 GETVARARGS R0 3
-MOVE R6 R0
-MOVE R7 R1
-CONCAT R4 R6 R7
+MOVE R5 R0
+MOVE R6 R1
+CONCAT R4 R5 R6
 MOVE R5 R2
 CONCAT R3 R4 R5
 RETURN R3 1
+)");
+}
+
+TEST_CASE("ConcatTopRegisterUse")
+{
+    ScopedFastFlag luauCompileConcatTargetTop{FFlag::LuauCompileConcatTargetTop, true};
+    
+    CHECK_EQ("\n" + compileFunction0("local a, b = ...; return '{a=' .. tostring(a) .. ' b=' .. tostring(b) .. '}'"), R"(
+GETVARARGS R0 2
+LOADK R3 K0 ['{a=']
+FASTCALL1 63 R0 L0
+MOVE R5 R0
+GETIMPORT R4 2 [tostring]
+CALL R4 1 1
+L0: LOADK R5 K3 [' b=']
+FASTCALL1 63 R1 L1
+MOVE R7 R1
+GETIMPORT R6 2 [tostring]
+CALL R6 1 1
+L1: LOADK R7 K4 ['}']
+CONCAT R2 R3 R7
+RETURN R2 1
 )");
 }
 


### PR DESCRIPTION
This is essentially a sequel to what #2324 did, just with a different expression being optimised this time. I tried to look for whatever cases I could, but this was the only one that seemed reasonably worthwhile to actually implement (everything else was a super rare case that didn't feel worthwhile to implement)

Since we're always using newly allocated registers off the end of the stack as our space for preparing concatenation, and since we advance the items in order, it's safe to use compileExprTempTop for compiling as all of the registers above are considered free at that point. This helps avoid cases where a MOVE would be emitted when not required, e.g. when a function call was involved (`return "{a=" .. tostring(a) .. "}"`)

Adds a test case, as the situation this optimises for is only barely covered by one of the existing test cases (reverse-order concatenation)

<details><summary>Example bytecode difference</summary>

Code: <code>local a, b = ...; return '{a=' .. tostring(a) .. ' b=' .. tostring(b) .. '}'</code>

Difference:
```
Function 0 (??):
   45: local a, b = ...; return '{a=' .. tostring(a) .. ' b=' .. tostring(b) .. '}'
GETVARARGS R0 2
LOADK R3 K0 ['{a=']
REMARK builtin tostring/1
FASTCALL1 63 R0 L0
MOVE R9 R0                   | MOVE R5 R0
GETIMPORT R8 2 [tostring]    | GETIMPORT R4 2 [tostring]
CALL R8 1 1                  | CALL R4 1 1
L0: MOVE R4 R8               | (Not present)
LOADK R5 K3 [' b=']          | L0: LOADK R5 K3 [' b=']
REMARK builtin tostring/1
FASTCALL1 63 R1 L1
MOVE R9 R1                   | MOVE R7 R1
GETIMPORT R8 2 [tostring]    | GETIMPORT R6 2 [tostring]
CALL R8 1 1                  | CALL R6 1 1
L1: MOVE R6 R8               | (Not present)
LOADK R7 K4 ['}']            | L1: LOADK R7 K4 ['}']
CONCAT R2 R3 R7
RETURN R2 1
```
</details>