### PR TITLE
Fix negated integer literals reporting a type error

### DIFF
--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -41,6 +41,7 @@ LUAU_FASTFLAG(DebugLuauLogSolverToJson)
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 LUAU_FASTINTVARIABLE(LuauPrimitiveInferenceInTableLimit, 500)
 LUAU_FASTFLAGVARIABLE(LuauDisallowRedefiningBuiltinTypes)
+LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(LuauTypeFunctionStructuredErrors)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAGVARIABLE(LuauDoNotEmplaceAnnotatedType)
@@ -3204,6 +3205,11 @@ Inference ConstraintGenerator::check(const ScopePtr& scope, AstExprUnary* unary)
     }
     case AstExprUnary::Op::Minus:
     {
+        // compileExprUnary folds `-1i` into one negative constant, so a negated integer literal is a value rather than
+        // an operation. A non-literal integer still reaches the runtime, which has no __unm, so it keeps the check.
+        if (FFlag::LuauIntegerType2 && unary->expr->is<AstExprConstantInteger>())
+            return Inference{builtinTypes->integerType, std::move(refinement)};
+
         TypeId resultType = createTypeFunctionInstance(builtinTypes->typeFunctions->unmFunc, {operandType}, {}, scope, unary->location);
         return Inference{resultType, std::move(refinement)};
     }

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -34,6 +34,7 @@
 
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 
+LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAGVARIABLE(LuauCheckFunctionStatementTypes)
 LUAU_FASTFLAGVARIABLE(LuauPropertyModifierMismatchErrors)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
@@ -2236,7 +2237,11 @@ void TypeChecker2::visit(AstExprUnary* expr)
     }
     else if (expr->op == AstExprUnary::Op::Minus)
     {
-        testIsSubtype(operandType, builtinTypes->numberType, expr->location);
+        // A negated integer literal is folded into one constant by the compiler, so it never negates anything.
+        if (FFlag::LuauIntegerType2 && expr->expr->is<AstExprConstantInteger>())
+            testIsSubtype(operandType, builtinTypes->integerType, expr->location);
+        else
+            testIsSubtype(operandType, builtinTypes->numberType, expr->location);
     }
     else if (expr->op == AstExprUnary::Op::Not)
     {

--- a/tests/TypeInfer.operators.test.cpp
+++ b/tests/TypeInfer.operators.test.cpp
@@ -18,6 +18,7 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
+LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
 LUAU_FASTFLAG(LuauConcatDoesntAlwaysReturnString)
 
@@ -1702,6 +1703,34 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "overload_concat")
     )");
 
     LUAU_CHECK_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "negated_integer_literal_is_a_constant")
+{
+    ScopedFastFlag sff{FFlag::LuauIntegerType2, true};
+
+    // compileExprUnary folds this into one negative constant, so it never negates anything at runtime.
+    CheckResult result = check(R"(
+        --!strict
+        local a = -4194626i
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK("integer" == toString(requireType("a")));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "negating_a_non_literal_integer_is_an_error")
+{
+    ScopedFastFlag sff{FFlag::LuauIntegerType2, true};
+
+    // Only the literal is folded. This one reaches the runtime, where integer has no __unm.
+    CheckResult result = check(R"(
+        --!strict
+        local b = 5i
+        local c = -b
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(2, result);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Luau's compiler folds `-1i` into a single constant representing that exact value, but Analysis has no matching case and reports an error on code that compiles and runs at every optimization level:
```luau
local a = -4194626i

-- TypeError: Operator '-' could not be applied to operand of type integer;
--         there is no corresponding overload for __unm
```

This PR fixes that so Analysis now recognises the negation being applied on a literal. `ConstraintGenerator` infers `integer` directly instead of instantiating `unm`, and `TypeChecker2` tests the operand against `integer` rather than `number`. `TypeChecker2` technically doesn't need to even test it at all, but it is kept for readability.

Negating an integer that is not a literal is untouched. That continues to throw at runtime with "attempt to perform arithmetic (unm) on integer" and Analysis reports the same error as shown above.