### PR TITLE
Differentiate inferred generic names from free type names

### DIFF
--- a/Analysis/include/Luau/ToString.h
+++ b/Analysis/include/Luau/ToString.h
@@ -160,6 +160,7 @@ std::string dump(const Constraint& c);
 std::string dump(const std::shared_ptr<Scope>& scope, const char* name);
 
 std::string generateName(size_t i);
+std::string generateGenericName(size_t i);
 
 std::string toString(const Position& position);
 std::string toString(const Location& location, int offset = 0, bool useBegin = true);

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -20,6 +20,7 @@
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauIntegerType2)
+LUAU_FASTFLAGVARIABLE(LuauDifferentiateFreeTypeAndGenericNames)
 
 /*
  * Enables increasing levels of verbosity for Luau type names when stringifying.
@@ -206,7 +207,9 @@ struct StringifierState
             seen.erase(ttv);
     }
 
-    std::string getName(TypeId ty)
+    int generatedGenericNamesCount = 0;
+
+    std::string getName(TypeId ty, bool forGeneric = false)
     {
         const size_t s = opts.nameMap.types.size();
         std::string& n = opts.nameMap.types[ty];
@@ -215,7 +218,14 @@ struct StringifierState
 
         for (int count = 0; count < 256; ++count)
         {
-            std::string candidate = generateName(usedNames.size() + count);
+            std::string candidate;
+            if (FFlag::LuauDifferentiateFreeTypeAndGenericNames && forGeneric)
+            {
+                candidate = generateGenericName(generatedGenericNamesCount + count);
+                generatedGenericNamesCount++;
+            }
+            else
+                candidate = generateName(usedNames.size() + count);
             if (!usedNames.contains(candidate))
             {
                 usedNames.insert(candidate);
@@ -224,12 +234,12 @@ struct StringifierState
             }
         }
 
-        return generateName(s);
+        return FFlag::LuauDifferentiateFreeTypeAndGenericNames && forGeneric ? generateGenericName(s) : generateName(s);
     }
 
     int previousNameIndex = 0;
 
-    std::string getName(TypePackId ty)
+    std::string getName(TypePackId ty, bool forGeneric = true)
     {
         const size_t s = opts.nameMap.typePacks.size();
         std::string& n = opts.nameMap.typePacks[ty];
@@ -238,7 +248,11 @@ struct StringifierState
 
         for (int count = 0; count < 256; ++count)
         {
-            std::string candidate = generateName(previousNameIndex + count);
+            std::string candidate;
+            if (FFlag::LuauDifferentiateFreeTypeAndGenericNames && forGeneric)
+                candidate = generateGenericName(previousNameIndex + count);
+            else
+                candidate = generateName(previousNameIndex + count);
             if (!usedNames.contains(candidate))
             {
                 previousNameIndex += count;
@@ -248,7 +262,7 @@ struct StringifierState
             }
         }
 
-        return generateName(s);
+        return FFlag::LuauDifferentiateFreeTypeAndGenericNames && forGeneric ? generateGenericName(s) : generateName(s);
     }
 
     void emit(const std::string& s)
@@ -556,7 +570,7 @@ struct TypeStringifier
             state.emit(gtv.name);
         }
         else
-            state.emit(state.getName(ty));
+            state.emit(state.getName(ty, /* forGeneric = */ true));
 
         if (FInt::DebugLuauVerboseTypeNames >= 1)
             state.emit(gtv.polarity);
@@ -1308,7 +1322,7 @@ struct TypePackStringifier
         }
         else
         {
-            state.emit(state.getName(tp));
+            state.emit(state.getName(tp, /* forGeneric = */ true));
         }
 
         if (FInt::DebugLuauVerboseTypeNames >= 1)
@@ -1928,6 +1942,15 @@ std::string generateName(size_t i)
     n = char('a' + i % 26);
     if (i >= 26)
         n += std::to_string(i / 26);
+    return n;
+}
+
+std::string generateGenericName(size_t i)
+{
+    std::string n;
+    n = char('A' + (i + 19) % 26);
+    if (i >= 26)
+        n += std::to_string(i / 26 + 1);
     return n;
 }
 

--- a/tests/ConstraintSolver.test.cpp
+++ b/tests/ConstraintSolver.test.cpp
@@ -5,6 +5,8 @@
 
 using namespace Luau;
 
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
+
 TEST_SUITE_BEGIN("ConstraintSolver");
 
 TEST_CASE_FIXTURE(Fixture, "constraint_basics")
@@ -19,6 +21,8 @@ TEST_CASE_FIXTURE(Fixture, "constraint_basics")
 
 TEST_CASE_FIXTURE(Fixture, "generic_function")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     check(R"(
         local function id(a)
             return a
@@ -26,7 +30,7 @@ TEST_CASE_FIXTURE(Fixture, "generic_function")
     )");
 
 
-    CHECK("<a>(a) -> a" == toString(requireType("id")));
+    CHECK("<T>(T) -> T" == toString(requireType("id")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "proper_let_generalization")

--- a/tests/Generalization.test.cpp
+++ b/tests/Generalization.test.cpp
@@ -17,6 +17,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(DebugLuauForbidInternalTypes)
 LUAU_FASTFLAG(LuauCollapseDirectBoundCycles)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("Generalization");
 
@@ -218,12 +219,14 @@ TEST_CASE_FIXTURE(GeneralizationFixture, "intersection_type_traversal_doesnt_cra
 
 TEST_CASE_FIXTURE(GeneralizationFixture, "('a) -> 'a")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     TypeId freeTy = freshType().first;
     TypeId fnTy = arena.addType(FunctionType{arena.addTypePack({freeTy}), arena.addTypePack({freeTy})});
 
     generalize(fnTy);
 
-    CHECK("<a>(a) -> a" == toString(fnTy));
+    CHECK("<T>(T) -> T" == toString(fnTy));
 }
 
 TEST_CASE_FIXTURE(GeneralizationFixture, "(t1, (t1 <: 'b)) -> () where t1 = ('a <: (t1 <: 'b) & {number} & {number})")
@@ -260,6 +263,8 @@ TEST_CASE_FIXTURE(GeneralizationFixture, "(('a <: number | string)) -> string?")
 
 TEST_CASE_FIXTURE(GeneralizationFixture, "(('a <: {'b})) -> ()")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     auto [aTy, aFree] = freshType();
     auto [bTy, bFree] = freshType();
 
@@ -274,11 +279,13 @@ TEST_CASE_FIXTURE(GeneralizationFixture, "(('a <: {'b})) -> ()")
 
     // The free type 'b is not replace with unknown because it appears in an
     // invariant context.
-    CHECK("<a>({a}) -> ()" == toString(functionTy));
+    CHECK("<T>({T}) -> ()" == toString(functionTy));
 }
 
 TEST_CASE_FIXTURE(GeneralizationFixture, "(('b <: {t1}), ('a <: t1)) -> t1 where t1 = (('a <: t1) <: 'c)")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     auto [aTy, aFree] = freshType();
     auto [bTy, bFree] = freshType();
     auto [cTy, cFree] = freshType();
@@ -295,7 +302,7 @@ TEST_CASE_FIXTURE(GeneralizationFixture, "(('b <: {t1}), ('a <: t1)) -> t1 where
 
     generalize(functionTy);
 
-    CHECK("<a>({a}, a) -> a" == toString(functionTy));
+    CHECK("<T>({T}, T) -> T" == toString(functionTy));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "generalization_traversal_should_re_traverse_unions_if_they_change_type")

--- a/tests/RuntimeLimits.test.cpp
+++ b/tests/RuntimeLimits.test.cpp
@@ -28,6 +28,7 @@ LUAU_FASTINT(LuauGenericCounterMaxSteps)
 LUAU_FASTINT(LuauSubtypingIterationLimit)
 LUAU_FASTINT(LuauStackGuardThreshold)
 LUAU_FASTINT(LuauNormalizerInitialFuel)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 struct LimitFixture : BuiltinsFixture
 {
@@ -488,6 +489,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "subtyping_should_cache_pairs_in_seen_set" * 
 TEST_CASE_FIXTURE(BuiltinsFixture, "test_generic_pruning_recursion_limit")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     ScopedFastInt sfi{FInt::LuauGenericCounterMaxSteps, 1};
 
@@ -496,7 +498,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "test_generic_pruning_recursion_limit")
             print(scale.Do.Re.Mi)
         end
     )"));
-    CHECK_EQ("<a>({ read Do: { read Re: { read Mi: a } } }) -> ()", toString(requireType("get")));
+    CHECK_EQ("<T>({ read Do: { read Re: { read Mi: T } } }) -> ()", toString(requireType("get")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "unification_runs_a_limited_number_of_iterations_before_stopping_subtyping" * doctest::timeout(4.0))

--- a/tests/Simplify.test.cpp
+++ b/tests/Simplify.test.cpp
@@ -10,6 +10,7 @@ using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_DYNAMIC_FASTINT(LuauSimplificationComplexityLimit)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 namespace
 {
@@ -182,11 +183,13 @@ TEST_CASE_FIXTURE(SimplifyFixture, "boolean_and_truthy_and_falsy")
 
 TEST_CASE_FIXTURE(SimplifyFixture, "any_and_indeterminate_types")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CHECK("'a | *error-type*" == intersectStr(anyTy, freeTy));
     CHECK("'a | *error-type*" == intersectStr(freeTy, anyTy));
 
-    CHECK("*error-type* | b" == intersectStr(anyTy, genericTy));
-    CHECK("*error-type* | b" == intersectStr(genericTy, anyTy));
+    CHECK("*error-type* | T" == intersectStr(anyTy, genericTy));
+    CHECK("*error-type* | T" == intersectStr(genericTy, anyTy));
 
     auto anyRhsBlocked = get<UnionType>(intersect(anyTy, blockedTy));
     auto anyLhsBlocked = get<UnionType>(intersect(blockedTy, anyTy));
@@ -259,11 +262,13 @@ TEST_CASE_FIXTURE(SimplifyFixture, "error_and_other_tops_and_bottom_types")
 
 TEST_CASE_FIXTURE(SimplifyFixture, "error_and_indeterminate_types")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CHECK("'a & *error-type*" == intersectStr(errorTy, freeTy));
     CHECK("'a & *error-type*" == intersectStr(freeTy, errorTy));
 
-    CHECK("*error-type* & b" == intersectStr(errorTy, genericTy));
-    CHECK("*error-type* & b" == intersectStr(genericTy, errorTy));
+    CHECK("*error-type* & T" == intersectStr(errorTy, genericTy));
+    CHECK("*error-type* & T" == intersectStr(genericTy, errorTy));
 
     CHECK(isIntersection(intersect(errorTy, blockedTy)));
     CHECK(isIntersection(intersect(blockedTy, errorTy)));

--- a/tests/ToDot.test.cpp
+++ b/tests/ToDot.test.cpp
@@ -10,6 +10,7 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver);
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 struct ToDotClassFixture : Fixture
 {
@@ -135,12 +136,14 @@ n2 [label="number"];
 
 TEST_CASE_FIXTURE(Fixture, "function")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
 local function f(a, ...: string) return a end
 )");
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ("<a>(a, ...string) -> a", toString(requireType("f")));
+    CHECK_EQ("<T>(T, ...string) -> T", toString(requireType("f")));
 
     ToDotOptions opts;
     opts.showPointers = false;

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -13,6 +13,7 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("ToString");
 
@@ -356,6 +357,8 @@ TEST_CASE_FIXTURE(Fixture, "stringifying_table_type_is_still_capped_when_exhaust
 
 TEST_CASE_FIXTURE(Fixture, "quit_stringifying_type_when_length_is_exceeded")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function f0() end
         function f1(f) return f or f0 end
@@ -370,9 +373,9 @@ TEST_CASE_FIXTURE(Fixture, "quit_stringifying_type_when_length_is_exceeded")
         o.exhaustive = false;
         o.maxTypeLength = 20;
         CHECK_EQ(toString(requireType("f0"), o), "() -> ()");
-        CHECK_EQ(toString(requireType("f1"), o), "<a>(a) -> (() -> ()) ... *TRUNCATED*");
-        CHECK_EQ(toString(requireType("f2"), o), "<b>(b) -> (<a>(a) -> (() -> ())... *TRUNCATED*");
-        CHECK_EQ(toString(requireType("f3"), o), "<c>(c) -> (<b>(b) -> (<a>(a) -> (() -> ())... *TRUNCATED*");
+        CHECK_EQ(toString(requireType("f1"), o), "<T>(T) -> (() -> ()) ... *TRUNCATED*");
+        CHECK_EQ(toString(requireType("f2"), o), "<V>(V) -> (<T>(T) -> (() -> ())... *TRUNCATED*");
+        CHECK_EQ(toString(requireType("f3"), o), "<X>(X) -> (<V>(V) -> (<T>(T) -> (() -> ())... *TRUNCATED*");
     }
     else
     {
@@ -390,6 +393,8 @@ TEST_CASE_FIXTURE(Fixture, "quit_stringifying_type_when_length_is_exceeded")
 
 TEST_CASE_FIXTURE(Fixture, "stringifying_type_is_still_capped_when_exhaustive")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function f0() end
         function f1(f) return f or f0 end
@@ -405,9 +410,9 @@ TEST_CASE_FIXTURE(Fixture, "stringifying_type_is_still_capped_when_exhaustive")
         o.exhaustive = true;
         o.maxTypeLength = 20;
         CHECK_EQ(toString(requireType("f0"), o), "() -> ()");
-        CHECK_EQ(toString(requireType("f1"), o), "<a>(a) -> (() -> ()) ... *TRUNCATED*");
-        CHECK_EQ(toString(requireType("f2"), o), "<b>(b) -> (<a>(a) -> (() -> ())... *TRUNCATED*");
-        CHECK_EQ(toString(requireType("f3"), o), "<c>(c) -> (<b>(b) -> (<a>(a) -> (() -> ())... *TRUNCATED*");
+        CHECK_EQ(toString(requireType("f1"), o), "<T>(T) -> (() -> ()) ... *TRUNCATED*");
+        CHECK_EQ(toString(requireType("f2"), o), "<V>(V) -> (<T>(T) -> (() -> ())... *TRUNCATED*");
+        CHECK_EQ(toString(requireType("f3"), o), "<X>(X) -> (<V>(V) -> (<T>(T) -> (() -> ())... *TRUNCATED*");
     }
     else
     {
@@ -530,6 +535,8 @@ local u: Foo
 
 TEST_CASE_FIXTURE(Fixture, "generate_friendly_names_for_inferred_generics")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function id(x) return x end
 
@@ -540,18 +547,20 @@ TEST_CASE_FIXTURE(Fixture, "generate_friendly_names_for_inferred_generics")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ("<a>(a) -> a", toString(requireType("id")));
+    CHECK_EQ("<T>(T) -> T", toString(requireType("id")));
 
     CHECK_EQ(
-        "<a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, a1, b1, c1, d1>(a, b, c, d, e, f, g, h, i, j, k, l, "
-        "m, n, o, p, q, r, s, t, u, v, w, x, y, z, a1, b1, c1, d1) -> (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, "
-        "x, y, z, a1, b1, c1, d1)",
+        "<T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T2, U2, V2, W2>(T, U, V, W, X, Y, Z, A, B, C, D, E, "
+        "F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T2, U2, V2, W2) -> (T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, "
+        "Q, R, S, T2, U2, V2, W2)",
         toString(requireType("id2"))
     );
 }
 
 TEST_CASE_FIXTURE(Fixture, "toStringDetailed")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function id3(a, b, c)
             return a, b, c
@@ -567,7 +576,7 @@ TEST_CASE_FIXTURE(Fixture, "toStringDetailed")
 
     REQUIRE(3 == opts.nameMap.types.size());
 
-    REQUIRE_EQ("<a, b, c>(a, b, c) -> (a, b, c)", nameData.name);
+    REQUIRE_EQ("<T, U, V>(T, U, V) -> (T, U, V)", nameData.name);
 
     const FunctionType* ftv = get<FunctionType>(follow(id3Type));
     REQUIRE(ftv != nullptr);
@@ -575,9 +584,9 @@ TEST_CASE_FIXTURE(Fixture, "toStringDetailed")
     auto params = flatten(ftv->argTypes).first;
     REQUIRE(3 == params.size());
 
-    CHECK("a" == toString(params[0], opts));
-    CHECK("b" == toString(params[1], opts));
-    CHECK("c" == toString(params[2], opts));
+    CHECK("T" == toString(params[0], opts));
+    CHECK("U" == toString(params[1], opts));
+    CHECK("V" == toString(params[2], opts));
 }
 
 TEST_CASE_FIXTURE(Fixture, "toStringErrorPack")
@@ -592,12 +601,14 @@ local function target(callback: nil) return callback(4, "hello") end
 
 TEST_CASE_FIXTURE(Fixture, "toStringGenericPack")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
 function foo(a, b) return a(b) end
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
-    CHECK_EQ(toString(requireType("foo")), "<a, b...>((a) -> (b...), a) -> (b...)");
+    CHECK_EQ(toString(requireType("foo")), "<T, U...>((T) -> (U...), T) -> (U...)");
 }
 
 TEST_CASE_FIXTURE(Fixture, "toString_the_boundTo_table_type_contained_within_a_TypePack")
@@ -673,6 +684,8 @@ TEST_CASE_FIXTURE(Fixture, "self_recursive_instantiated_param")
 
 TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_id")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function id(x) return x end
     )");
@@ -680,11 +693,13 @@ TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_id")
     TypeId ty = requireType("id");
     const FunctionType* ftv = get<FunctionType>(follow(ty));
 
-    CHECK_EQ("id<a>(x: a): a", toStringNamedFunction("id", *ftv));
+    CHECK_EQ("id<T>(x: T): T", toStringNamedFunction("id", *ftv));
 }
 
 TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_map")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function map(arr, fn)
             local t = {}
@@ -699,9 +714,9 @@ TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_map")
     const FunctionType* ftv = get<FunctionType>(follow(ty));
 
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK_EQ("map<a, b>(arr: {a}, fn: (a) -> (b, ...unknown)): {b}", toStringNamedFunction("map", *ftv));
+        CHECK_EQ("map<T, U>(arr: {T}, fn: (T) -> (U, ...unknown)): {U}", toStringNamedFunction("map", *ftv));
     else
-        CHECK_EQ("map<a, b>(arr: {a}, fn: (a) -> b): {b}", toStringNamedFunction("map", *ftv));
+        CHECK_EQ("map<T, U>(arr: {T}, fn: (T) -> U): {U}", toStringNamedFunction("map", *ftv));
 }
 
 TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_generic_pack")
@@ -798,6 +813,8 @@ TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_hide_type_params")
 
 TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_overrides_param_names")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function test(a, b : string, ... : number) return a end
     )");
@@ -807,7 +824,7 @@ TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_overrides_param_names")
 
     ToStringOptions opts;
     opts.namedFunctionOverrideArgNames = {"first", "second", "third"};
-    CHECK_EQ("test<a>(first: a, second: string, ...: number): a", toStringNamedFunction("test", *ftv, opts));
+    CHECK_EQ("test<T>(first: T, second: string, ...: number): T", toStringNamedFunction("test", *ftv, opts));
 }
 
 TEST_CASE_FIXTURE(Fixture, "pick_distinct_names_for_mixed_explicit_and_implicit_generics")

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -17,6 +17,7 @@ LUAU_DYNAMIC_FASTINT(LuauTypeFamilyApplicationCartesianProductLimit)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauDoNotExportBrokenTypeFunction)
 LUAU_FASTFLAG(LuauCloneTypeFunctionFromForeignArena)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 struct TypeFunctionFixture : Fixture
 {
@@ -302,6 +303,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "type_functions_can_be_shadowed")
     if (FFlag::DebugLuauForceOldSolver)
         return;
 
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         type add<T> = string -- shadow add
 
@@ -319,7 +322,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "type_functions_can_be_shadowed")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     CHECK(toString(requireType("hi")) == "(string) -> string");
-    CHECK(toString(requireType("plus")) == "<a, b>(a, b) -> add<a, b>");
+    CHECK(toString(requireType("plus")) == "<T, U>(T, U) -> add<T, U>");
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "type_functions_inhabited_with_normalization")

--- a/tests/TypeInfer.annotations.test.cpp
+++ b/tests/TypeInfer.annotations.test.cpp
@@ -9,6 +9,7 @@
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(DebugLuauMagicTypes)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 using namespace Luau;
 
@@ -939,6 +940,7 @@ TEST_CASE_FIXTURE(Fixture, "instantiation_clone_has_to_follow")
 TEST_CASE_FIXTURE(Fixture, "unifier3_supertail_covariant_with_sub")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     CheckResult result = check(R"(
         local function fib(n)
@@ -946,7 +948,7 @@ TEST_CASE_FIXTURE(Fixture, "unifier3_supertail_covariant_with_sub")
         end
     )");
 
-    CHECK_EQ("<a>(a) -> t1 where t1 = add<a, t1>", toString(requireType("fib")));
+    CHECK_EQ("<T>(T) -> t1 where t1 = add<T, t1>", toString(requireType("fib")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "respect_partially_annotated_type_packs_1")

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -25,6 +25,7 @@ LUAU_FASTFLAG(LuauBidirectionalInferenceVariadics)
 LUAU_FASTFLAG(LuauBidirectionalInferenceBetterLambdaHandling)
 LUAU_FASTFLAG(LuauHigherOrderGenericInference)
 LUAU_FASTFLAG(LuauCollapseDirectBoundCycles)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -169,6 +170,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_that_function_does_not_return_a_table")
 
 TEST_CASE_FIXTURE(Fixture, "generalize_table_property")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local T = {}
 
@@ -186,7 +189,7 @@ TEST_CASE_FIXTURE(Fixture, "generalize_table_property")
     const Property& foo = tt->props.at("foo");
     REQUIRE(foo.readTy);
     TypeId fooTy = *foo.readTy;
-    CHECK("<a>(a) -> a" == toString(fooTy));
+    CHECK("<T>(T) -> T" == toString(fooTy));
 }
 
 TEST_CASE_FIXTURE(Fixture, "vararg_functions_should_allow_calls_of_any_types_and_size")
@@ -724,6 +727,7 @@ TEST_CASE_FIXTURE(Fixture, "higher_order_function_2")
 TEST_CASE_FIXTURE(Fixture, "higher_order_function_3")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     CheckResult result = check(R"(
         function swap(p)
@@ -753,7 +757,7 @@ TEST_CASE_FIXTURE(Fixture, "higher_order_function_3")
     // future via Unifier3, as we'll be able to observe that the upper bound
     // of `p` in `swapTwice` will be `{ 'a }` and not create two indexer
     // upper bounds.
-    CHECK_EQ("<a, b>({a} & {b}) -> {a} & {b}", toString(requireType("swapTwice")));
+    CHECK_EQ("<T, U>({T} & {U}) -> {T} & {U}", toString(requireType("swapTwice")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "higher_order_function_4")
@@ -1246,6 +1250,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "infer_anonymous_function_arguments")
 {
     // FIXME: CLI-116133 bidirectional type inference needs to push expected types in for higher-order function calls
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     // Simple direct arg to arg propagation
     CheckResult result = check(R"(
@@ -1308,7 +1313,7 @@ f(function(a, b, c, ...) return a + b end)
         expected = "Expected this to be\n\t"
                    "'(number, number) -> number'"
                    "\nbut got\n\t"
-                   "'<a>(number, number, a) -> number'"
+                   "'<T>(number, number, T) -> number'"
                    "\ncaused by:\n"
                    "  Argument count mismatch. Function expects 3 arguments, but only 2 are specified";
     }
@@ -1926,6 +1931,8 @@ TEST_CASE_FIXTURE(Fixture, "free_is_not_bound_to_unknown")
 
 TEST_CASE_FIXTURE(Fixture, "dont_infer_parameter_types_for_functions_from_their_call_site")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local t = {}
 
@@ -1944,7 +1951,7 @@ TEST_CASE_FIXTURE(Fixture, "dont_infer_parameter_types_for_functions_from_their_
     )");
 
 
-    CHECK_EQ("<a>(a) -> a", toString(requireType("f")));
+    CHECK_EQ("<T>(T) -> T", toString(requireType("f")));
 
     if (!FFlag::DebugLuauForceOldSolver)
     {
@@ -3213,6 +3220,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "io_manager_oop_ish")
 TEST_CASE_FIXTURE(BuiltinsFixture, "generic_function_statement")
 {
     ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         type Object = {
@@ -3230,7 +3238,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "generic_function_statement")
     CHECK_EQ("number", toString(requireTypeAtPosition({7, 24})));
     CHECK_EQ("string", toString(requireTypeAtPosition({8, 24})));
     // NOTE: This specifically _isn't_ `T` as defined by `Object.foobar`
-    CHECK_EQ("a", toString(requireTypeAtPosition({9, 21})));
+    CHECK_EQ("T", toString(requireTypeAtPosition({9, 21})));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "function_calls_should_not_crash")

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -11,6 +11,7 @@ LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauInstantiateFunctionTypeBeforePush)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 using namespace Luau;
 
@@ -1157,6 +1158,8 @@ wrapper(foo, test2, "3") -- not ok (type mismatch, string instead of number)
 
 TEST_CASE_FIXTURE(Fixture, "generic_function")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function id(x) return x end
         local a = id(55)
@@ -1165,7 +1168,7 @@ TEST_CASE_FIXTURE(Fixture, "generic_function")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ("<a>(a) -> a", toString(requireType("id")));
+    CHECK_EQ("<T>(T) -> T", toString(requireType("id")));
     CHECK("number" == toString(requireType("a")));
     CHECK("nil" == toString(requireType("b")));
 }
@@ -1286,6 +1289,8 @@ TEST_CASE_FIXTURE(Fixture, "instantiate_cyclic_generic_function")
 
 TEST_CASE_FIXTURE(Fixture, "instantiate_generic_function_in_assignments")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function foo(a, b)
             return a(b)
@@ -1308,13 +1313,15 @@ TEST_CASE_FIXTURE(Fixture, "instantiate_generic_function_in_assignments")
     // are set, assert that we're getting back the original generic
     // function definition.
     if (FFlag::LuauInstantiateInSubtyping || !FFlag::DebugLuauForceOldSolver)
-        CHECK_EQ("<a, b...>((a) -> (b...), a) -> (b...)", toString(tm->givenType));
+        CHECK_EQ("<T, U...>((T) -> (U...), T) -> (U...)", toString(tm->givenType));
     else
         CHECK_EQ("((number) -> number, number) -> number", toString(tm->givenType));
 }
 
 TEST_CASE_FIXTURE(Fixture, "instantiate_generic_function_in_assignments2")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function foo(a, b)
             return a(b)
@@ -1335,7 +1342,7 @@ TEST_CASE_FIXTURE(Fixture, "instantiate_generic_function_in_assignments2")
     // are set, assert that we're getting back the original generic
     // function definition.
     if (FFlag::LuauInstantiateInSubtyping || !FFlag::DebugLuauForceOldSolver)
-        CHECK_EQ("<a, b...>((a) -> (b...), a) -> (b...)", toString(tm->givenType));
+        CHECK_EQ("<T, U...>((T) -> (U...), T) -> (U...)", toString(tm->givenType));
     else
         CHECK_EQ("((string) -> number, string) -> number", toString(*tm->givenType));
 }
@@ -1644,24 +1651,28 @@ TEST_CASE_FIXTURE(Fixture, "apply_type_function_nested_generics3")
 
 TEST_CASE_FIXTURE(Fixture, "quantify_functions_with_no_generics")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function foo(f, x)
             return f(x)
         end
     )");
 
-    CHECK("<a, b...>((a) -> (b...), a) -> (b...)" == toString(requireType("foo")));
+    CHECK("<T, U...>((T) -> (U...), T) -> (U...)" == toString(requireType("foo")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "quantify_functions_even_if_they_have_an_explicit_generic")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function foo<X>(f, x: X)
             return f(x)
         end
     )");
 
-    CHECK("<X, a...>((X) -> (a...), X) -> (a...)" == toString(requireType("foo")));
+    CHECK("<X, T...>((X) -> (T...), X) -> (T...)" == toString(requireType("foo")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "no_extra_quantification_for_generic_functions")
@@ -1782,6 +1793,7 @@ TEST_CASE_FIXTURE(Fixture, "missing_generic_type_parameter")
 TEST_CASE_FIXTURE(Fixture, "generic_implicit_explicit_name_clash")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     auto result = check(R"(
         function apply<a>(func, argument: a)
@@ -1789,7 +1801,7 @@ TEST_CASE_FIXTURE(Fixture, "generic_implicit_explicit_name_clash")
         end
     )");
 
-    CHECK("<a, b...>((a) -> (b...), a) -> (b...)" == toString(requireType("apply")));
+    CHECK("<a, T...>((a) -> (T...), a) -> (T...)" == toString(requireType("apply")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "generic_type_functions_work_in_subtyping")

--- a/tests/TypeInfer.operators.test.cpp
+++ b/tests/TypeInfer.operators.test.cpp
@@ -20,6 +20,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
 LUAU_FASTFLAG(LuauConcatDoesntAlwaysReturnString)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TypeInferOperators");
 
@@ -779,6 +780,8 @@ TEST_CASE_FIXTURE(Fixture, "unknown_type_in_comparison")
 
 TEST_CASE_FIXTURE(Fixture, "concat_op_on_free_lhs_and_string_rhs")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function f(x)
             return x .. "y"
@@ -788,7 +791,7 @@ TEST_CASE_FIXTURE(Fixture, "concat_op_on_free_lhs_and_string_rhs")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK("<a>(a) -> concat<a, string>" == toString(requireType("f")));
+        CHECK("<T>(T) -> concat<T, string>" == toString(requireType("f")));
     }
     else
     {
@@ -799,6 +802,8 @@ TEST_CASE_FIXTURE(Fixture, "concat_op_on_free_lhs_and_string_rhs")
 
 TEST_CASE_FIXTURE(Fixture, "concat_op_on_string_lhs_and_free_rhs")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function f(x)
             return "foo" .. x
@@ -808,7 +813,7 @@ TEST_CASE_FIXTURE(Fixture, "concat_op_on_string_lhs_and_free_rhs")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK("<a>(a) -> concat<string, a>" == toString(requireType("f")));
+        CHECK("<T>(T) -> concat<string, T>" == toString(requireType("f")));
     else
         CHECK_EQ("(string) -> string", toString(requireType("f")));
 }
@@ -1074,6 +1079,8 @@ TEST_CASE_FIXTURE(Fixture, "refine_and_or")
 
 TEST_CASE_FIXTURE(Fixture, "infer_any_in_all_modes_when_lhs_is_unknown")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x + y
@@ -1083,7 +1090,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_any_in_all_modes_when_lhs_is_unknown")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> add<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> add<T, U>");
     }
     else
     {
@@ -1106,6 +1113,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_any_in_all_modes_when_lhs_is_unknown")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_subtraction")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x - y
@@ -1115,7 +1124,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_subtraction")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> sub<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> sub<T, U>");
     }
     else
     {
@@ -1126,6 +1135,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_subtraction")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_multiplication")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x * y
@@ -1135,7 +1146,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_multiplication")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> mul<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> mul<T, U>");
     }
     else
     {
@@ -1146,6 +1157,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_multiplication")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_division")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x / y
@@ -1155,7 +1168,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_division")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> div<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> div<T, U>");
     }
     else
     {
@@ -1166,6 +1179,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_division")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_floor_division")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x // y
@@ -1175,7 +1190,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_floor_division")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> idiv<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> idiv<T, U>");
     }
     else
     {
@@ -1186,6 +1201,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_floor_division")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_exponentiation")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x ^ y
@@ -1195,7 +1212,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_exponentiation")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> pow<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> pow<T, U>");
     }
     else
     {
@@ -1206,6 +1223,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_exponentiation")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_modulo")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x % y
@@ -1215,7 +1234,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_modulo")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> mod<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> mod<T, U>");
     }
     else
     {
@@ -1226,6 +1245,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_modulo")
 
 TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_concat")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(Mode::Strict, R"(
         local function f(x, y)
             return x .. y
@@ -1235,7 +1256,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_for_generic_concat")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK(toString(requireType("f")) == "<a, b>(a, b) -> concat<a, b>");
+        CHECK(toString(requireType("f")) == "<T, U>(T, U) -> concat<T, U>");
     }
     else
     {

--- a/tests/TypeInfer.refinements.test.cpp
+++ b/tests/TypeInfer.refinements.test.cpp
@@ -13,6 +13,7 @@ LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
 LUAU_FASTFLAG(LuauIndexingIntoErrorGivesError);
 LUAU_FASTFLAG(LuauAvoidTrivialPhis)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 using namespace Luau;
 
@@ -356,6 +357,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeguard_in_if_condition_position")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "typeguard_in_assert_position")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function f(a)
             assert(type(a) == "number")
@@ -367,9 +370,9 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeguard_in_assert_position")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK("<a>(a) -> a & number" == toString(requireType("f")));
+        CHECK("<T>(T) -> T & number" == toString(requireType("f")));
     else
-        CHECK("<a>(a) -> number" == toString(requireType("f")));
+        CHECK("<T>(T) -> number" == toString(requireType("f")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "refine_unknown_to_table_then_test_a_prop")
@@ -1445,6 +1448,8 @@ TEST_CASE_FIXTURE(RefinementExternTypeFixture, "typeguard_cast_free_table_to_vec
 {
     // CLI-115286 - Refining via type(x) == 'vector' does not work in the new solver
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     getFrontend().setLuauSolverMode(!FFlag::DebugLuauForceOldSolver ? SolverMode::New : SolverMode::Old);
     CheckResult result = check(R"(
         local function f(vec)
@@ -1466,7 +1471,7 @@ TEST_CASE_FIXTURE(RefinementExternTypeFixture, "typeguard_cast_free_table_to_vec
 
     CHECK_EQ("never", toString(requireTypeAtPosition({7, 28}))); // typeof(vec) == "Instance"
 
-    CHECK_EQ("{+ X: a, Y: b, Z: c +}", toString(requireTypeAtPosition({9, 28}))); // type(vec) ~= "vector" and typeof(vec) ~= "Instance"
+    CHECK_EQ("{+ X: T, Y: U, Z: V +}", toString(requireTypeAtPosition({9, 28}))); // type(vec) ~= "vector" and typeof(vec) ~= "Instance"
 }
 
 TEST_CASE_FIXTURE(RefinementExternTypeFixture, "typeguard_cast_instance_or_vector3_to_vector")

--- a/tests/TypeInfer.singletons.test.cpp
+++ b/tests/TypeInfer.singletons.test.cpp
@@ -9,6 +9,7 @@ using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TypeSingletons");
 
@@ -486,6 +487,7 @@ local a: Animal = if true then { tag = 'cat', catfood = 'something' } else { tag
 TEST_CASE_FIXTURE(Fixture, "widen_the_supertype_if_it_is_free_and_subtype_has_singleton")
 {
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     CheckResult result = check(R"(
         local function foo(f, x)
@@ -500,12 +502,13 @@ TEST_CASE_FIXTURE(Fixture, "widen_the_supertype_if_it_is_free_and_subtype_has_si
 
     CHECK_EQ(R"("hi")", toString(requireTypeAtPosition({3, 18})));
     // should be <a...>((string) -> a..., string) -> () but needs lower bounds calculation
-    CHECK_EQ("<a, b...>((string) -> (b...), a) -> ()", toString(requireType("foo")));
+    CHECK_EQ("<T, U...>((string) -> (U...), T) -> ()", toString(requireType("foo")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "return_type_of_f_is_not_widened")
 {
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     CheckResult result = check(R"(
         local function foo(f, x): "hello"? -- anyone there?
@@ -518,7 +521,7 @@ TEST_CASE_FIXTURE(Fixture, "return_type_of_f_is_not_widened")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     CHECK_EQ(R"("hi")", toString(requireTypeAtPosition({3, 23})));
-    CHECK_EQ(R"(<a, b, c...>((string) -> (a, c...), b) -> "hello"?)", toString(requireType("foo")));
+    CHECK_EQ(R"(<T, U, V...>((string) -> (T, V...), U) -> "hello"?)", toString(requireType("foo")));
     // CHECK_EQ(R"(<a, b...>((string) -> ("hello"?, b...), a) -> "hello"?)", toString(requireType("foo")));
 }
 

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -29,6 +29,7 @@ LUAU_FASTFLAG(LuauPropertyModifierMismatchErrors)
 LUAU_FASTFLAG(LuauRemoveConstraintSolverEmplace)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
 LUAU_FASTFLAG(LuauAlwaysIntersectTablesWithTables)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TableTests");
 
@@ -700,6 +701,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_array_2")
 
 TEST_CASE_FIXTURE(Fixture, "indexers_get_quantified_too")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function swap(p)
             local temp = p[0]
@@ -711,7 +714,7 @@ TEST_CASE_FIXTURE(Fixture, "indexers_get_quantified_too")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK("<a>({a}) -> ()" == toString(requireType("swap")));
+        CHECK("<T>({T}) -> ()" == toString(requireType("swap")));
     else
     {
         const FunctionType* ftv = get<FunctionType>(requireType("swap"));
@@ -3666,6 +3669,8 @@ TEST_CASE_FIXTURE(Fixture, "scalar_is_a_subtype_of_a_compatible_polymorphic_shap
 
 TEST_CASE_FIXTURE(Fixture, "scalar_is_not_a_subtype_of_a_compatible_polymorphic_shape_type")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function f(s)
             return s:absolutely_no_scalar_has_this_method()
@@ -3686,51 +3691,51 @@ TEST_CASE_FIXTURE(Fixture, "scalar_is_not_a_subtype_of_a_compatible_polymorphic_
         TypeMismatch* tm1 = get<TypeMismatch>(result.errors[0]);
         REQUIRE(tm1);
         CHECK("typeof(string)" == toString(tm1->givenType));
-        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (a...) }" == toString(tm1->wantedType));
+        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (T...) }" == toString(tm1->wantedType));
 
         TypeMismatch* tm2 = get<TypeMismatch>(result.errors[1]);
         REQUIRE(tm2);
         CHECK("typeof(string)" == toString(tm2->givenType));
-        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (a...) }" == toString(tm2->wantedType));
+        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (T...) }" == toString(tm2->wantedType));
 
         TypeMismatch* tm3 = get<TypeMismatch>(result.errors[2]);
         REQUIRE(tm3);
         CHECK("typeof(string)" == toString(tm3->givenType));
-        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (a...) }" == toString(tm3->wantedType));
+        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (T...) }" == toString(tm3->wantedType));
 
         TypeMismatch* tm4 = get<TypeMismatch>(result.errors[3]);
         REQUIRE(tm4);
         CHECK("typeof(string)" == toString(tm4->givenType));
-        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (a...) }" == toString(tm4->wantedType));
+        CHECK("t1 where t1 = { read absolutely_no_scalar_has_this_method: (t1) -> (T...) }" == toString(tm4->wantedType));
     }
     else
     {
         LUAU_REQUIRE_ERROR_COUNT(3, result);
 
         const std::string expected1 =
-            R"(Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}', but got 'string'
+            R"(Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}', but got 'string'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
         CHECK_EQ(expected1, toString(result.errors[0]));
 
         const std::string expected2 =
-            R"(Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}', but got '"bar"'
+            R"(Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}', but got '"bar"'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
         CHECK_EQ(expected2, toString(result.errors[1]));
 
         const std::string expected3 = R"(Expected this to be
-	't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}'
+	't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}'
 but got
 	'"bar" | "baz"'
 caused by:
   Not all union options are compatible.
-Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}', but got '"bar"'
+Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}', but got '"bar"'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (T...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
         CHECK_EQ(expected3, toString(result.errors[2]));
     }
 }
@@ -4800,6 +4805,8 @@ TEST_CASE_FIXTURE(Fixture, "table_writes_introduce_write_properties")
     if (FFlag::DebugLuauForceOldSolver)
         return;
 
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function oc(player, speaker)
             local head = speaker.Character:FindFirstChild('Head')
@@ -4810,9 +4817,9 @@ TEST_CASE_FIXTURE(Fixture, "table_writes_introduce_write_properties")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     CHECK(
-        "<a>({{ read Character: t1 }}, { Character: t1 }) -> () "
+        "<T>({{ read Character: t1 }}, { Character: t1 }) -> () "
         "where "
-        "t1 = { read FindFirstChild: (t1, string) -> (a, ...unknown) }" == toString(requireType("oc"))
+        "t1 = { read FindFirstChild: (t1, string) -> (T, ...unknown) }" == toString(requireType("oc"))
     );
 }
 
@@ -4837,6 +4844,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "tables_can_have_both_metatables_and_indexers
 
 TEST_CASE_FIXTURE(Fixture, "refined_thing_can_be_an_array")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function foo(x, y)
             if x then
@@ -4848,7 +4857,7 @@ TEST_CASE_FIXTURE(Fixture, "refined_thing_can_be_an_array")
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
-    CHECK("<a>({a}, a) -> a" == toString(requireType("foo")));
+    CHECK("<T>({T}, T) -> T" == toString(requireType("foo")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "parameter_was_set_an_indexer_and_bounded_by_string")
@@ -5263,8 +5272,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "subtyping_with_a_metatable_table_path")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_union_type")
 {
-
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     // This will have one (legitimate) error but previously would crash.
     auto result = check(R"(
@@ -5281,7 +5290,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_union_type")
     )");
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK_EQ(
-        "Cannot add indexer to table '{ @metatable t1, (nil & ~(false?)) | {  } } where t1 = { new: <a>(a) -> { @metatable t1, (a & ~(false?)) | {  "
+        "Cannot add indexer to table '{ @metatable t1, (nil & ~(false?)) | {  } } where t1 = { new: <T>(T) -> { @metatable t1, (T & ~(false?)) | {  "
         "} } }'",
         toString(result.errors[0])
     );

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -33,6 +33,7 @@ LUAU_FASTFLAG(LuauSubtypingMissingPropertiesAsNil)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauDontBindOptionalGenericToNil)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 using namespace Luau;
 
@@ -1141,6 +1142,7 @@ end
 TEST_CASE_FIXTURE(Fixture, "cli_50041_committing_txnlog_in_apollo_client_error")
 {
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -1185,7 +1187,7 @@ TEST_CASE_FIXTURE(Fixture, "cli_50041_committing_txnlog_in_apollo_client_error")
             "Expected this to be exactly\n\t"
             "'(Policies, FieldSpecifier) -> string'"
             "\nbut got\n\t"
-            "'(Policies, FieldSpecifier & { from: number? }) -> ('a, b...)'"
+            "'(Policies, FieldSpecifier & { from: number? }) -> ('a, T...)'"
             "\ncaused by:\n"
             "  Argument #2 type is not compatible.\n"
             "Expected this to be exactly\n\t"

--- a/tests/TypeInfer.typePacks.test.cpp
+++ b/tests/TypeInfer.typePacks.test.cpp
@@ -12,6 +12,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TypePackTests");
 
@@ -87,6 +88,8 @@ TEST_CASE_FIXTURE(Fixture, "last_element_of_return_statement_can_itself_be_a_pac
 
 TEST_CASE_FIXTURE(Fixture, "higher_order_function")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         function apply(f, g, x)
             return f(g(x))
@@ -96,9 +99,9 @@ TEST_CASE_FIXTURE(Fixture, "higher_order_function")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK_EQ("<a, b..., c...>((c...) -> (b...), (a) -> (c...), a) -> (b...)", toString(requireType("apply")));
+        CHECK_EQ("<T, U..., V...>((V...) -> (U...), (T) -> (V...), T) -> (U...)", toString(requireType("apply")));
     else
-        CHECK_EQ("<a, b..., c...>((b...) -> (c...), (a) -> (b...), a) -> (c...)", toString(requireType("apply")));
+        CHECK_EQ("<T, U..., V...>((U...) -> (V...), (T) -> (U...), T) -> (V...)", toString(requireType("apply")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "return_type_should_be_empty_if_nothing_is_returned")

--- a/tests/TypeInfer.unionTypes.test.cpp
+++ b/tests/TypeInfer.unionTypes.test.cpp
@@ -11,6 +11,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauSubtypeUnionsTogether)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("UnionTypes");
 
@@ -892,6 +893,8 @@ TEST_CASE_FIXTURE(Fixture, "less_greedy_unification_with_union_types")
     if (FFlag::DebugLuauForceOldSolver)
         return;
 
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function f(t): { x: number } | { x: string }
             local x = t.x
@@ -901,7 +904,7 @@ TEST_CASE_FIXTURE(Fixture, "less_greedy_unification_with_union_types")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ("<a>(({ read x: a } & { x: number }) | ({ read x: a } & { x: string })) -> { x: number } | { x: string }", toString(requireType("f")));
+    CHECK_EQ("<T>(({ read x: T } & { x: number }) | ({ read x: T } & { x: string })) -> { x: number } | { x: string }", toString(requireType("f")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "less_greedy_unification_with_union_types_2")

--- a/tests/TypeInfer.unknownnever.test.cpp
+++ b/tests/TypeInfer.unknownnever.test.cpp
@@ -7,6 +7,7 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver);
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TypeInferUnknownNever");
 
@@ -343,6 +344,8 @@ TEST_CASE_FIXTURE(Fixture, "dont_unify_operands_if_one_of_the_operand_is_never_i
 
 TEST_CASE_FIXTURE(Fixture, "math_operators_and_never")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     CheckResult result = check(R"(
         local function mul(x: nil, y)
             return x ~= nil and x * y -- infers boolean | never, which is normalized into boolean
@@ -356,12 +359,12 @@ TEST_CASE_FIXTURE(Fixture, "math_operators_and_never")
 
         // CLI-114134 Egraph-based simplification.
         // CLI-116549 x ~= nil : false when x : nil
-        CHECK("<a>(nil, a) -> false | mul<nil & ~nil, a>" == toString(requireType("mul")));
+        CHECK("<T>(nil, T) -> false | mul<nil & ~nil, T>" == toString(requireType("mul")));
     }
     else
     {
         LUAU_REQUIRE_NO_ERRORS(result);
-        CHECK_EQ("<a>(nil, a) -> boolean", toString(requireType("mul")));
+        CHECK_EQ("<T>(nil, T) -> boolean", toString(requireType("mul")));
     }
 }
 

--- a/tests/TypeVar.test.cpp
+++ b/tests/TypeVar.test.cpp
@@ -11,6 +11,7 @@
 
 using namespace Luau;
 
+LUAU_FASTFLAG(LuauDifferentiateFreeTypeAndGenericNames)
 
 TEST_SUITE_BEGIN("TypeTests");
 
@@ -36,6 +37,8 @@ TEST_CASE_FIXTURE(Fixture, "return_type_of_function_is_parenthesized_if_not_just
 
 TEST_CASE_FIXTURE(Fixture, "return_type_of_function_is_parenthesized_if_tail_is_free")
 {
+    ScopedFastFlag differentiateFreeTypesAndGenerics{FFlag::LuauDifferentiateFreeTypeAndGenericNames, true};
+
     auto emptyArgumentPack = TypePackVar{TypePack{}};
     auto free = FreeTypePack(TypeLevel());
     auto freePack = TypePackVar{TypePackVariant{free}};
@@ -43,7 +46,7 @@ TEST_CASE_FIXTURE(Fixture, "return_type_of_function_is_parenthesized_if_tail_is_
     auto returnsTwo = Type(FunctionType(getFrontend().globals.globalScope->level, &emptyArgumentPack, &returnPack));
 
     std::string res = toString(&returnsTwo);
-    CHECK_EQ(res, "() -> (number, a...)");
+    CHECK_EQ(res, "() -> (number, T...)");
 }
 
 TEST_CASE_FIXTURE(Fixture, "subset_check")


### PR DESCRIPTION
Flagged behind `LuauDifferentiateFreeTypeAndGenericNames`.

When unnamed generic types (usually inferred polymorphism) are stringified, they will now start from uppercase `T`. When looping back around, they will also count up from `2` instead of `1` (compared to generated free type names).

This does not affect the output of `luau-analyze --annotate`, as that generates its own names.