### PR TITLE
Expose the integer type to user-defined type functions

### DIFF
--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -506,6 +506,15 @@ static int createNumber(lua_State* L)
     return 1;
 }
 
+// Luau: `type.integer`
+// Returns the type instance representing integer
+static int createInteger(lua_State* L)
+{
+    allocTypeUserData(L, TypeFunctionPrimitiveType{TypeFunctionPrimitiveType::Integer});
+
+    return 1;
+}
+
 // Luau: `type.string`
 // Returns the type instance representing string
 static int createString(lua_State* L)
@@ -1944,6 +1953,14 @@ void registerTypesLibrary(lua_State* L)
     {
         l->func(L);
         lua_setfield(L, -2, l->name);
+    }
+
+    // `integer` is only nameable in type annotations when the flag is on, so only expose a
+    // constructor for it under the same condition
+    if (FFlag::LuauIntegerType2)
+    {
+        createInteger(L);
+        lua_setfield(L, -2, "integer");
     }
 
     lua_pop(L, 1);

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -3176,6 +3176,60 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_cloner_missing_integer_crashes_copy")
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_integer_methods_work")
+{
+    ScopedFastFlag newSolver{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag integerType{FFlag::LuauIntegerType2, true};
+
+    CheckResult result = check(R"(
+        type function getinteger()
+            local ty = types.integer
+            if ty:is("integer") then
+                return ty
+            end
+            -- this should never be returned
+            return types.string
+        end
+        local function ok(idx: getinteger<>): integer return idx end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_integer_is_distinct_from_number")
+{
+    ScopedFastFlag newSolver{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag integerType{FFlag::LuauIntegerType2, true};
+
+    CheckResult result = check(R"(
+        type function pick(arg)
+            if arg:is("integer") then
+                return types.integer
+            end
+            return types.number
+        end
+        local function ok(idx: pick<integer>): integer return idx end
+        local function ok2(idx: pick<number>): number return idx end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_integer_constructor_is_not_number")
+{
+    ScopedFastFlag newSolver{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag integerType{FFlag::LuauIntegerType2, true};
+
+    CheckResult result = check(R"(
+        type function getinteger()
+            return types.integer
+        end
+        local function bad(idx: getinteger<>): number return idx end
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_setgenerics_wrong_argcount_check")
 {
     ScopedFastFlag newSolver{FFlag::DebugLuauForceOldSolver, false};


### PR DESCRIPTION
`integer` is currently missing a constructor in the type function `types` library, so a type function could receive and inspect an integer type but never produce one.

Everything else was already in place: serialization, deserialization, deep copy, and the `"integer"` tag. This adds `createInteger` alongside `createNumber` and registers it.

Registration is gated on `LuauIntegerType2`, matching the gate on the `integer` type binding in `GlobalTypes.cpp:21`, so a type function cannot construct a type that is not nameable in an annotation. Note that the surrounding gating is already uneven: the serde and copy paths are ungated and only the tag lookup checks the flag. Happy to drop the gate if that is preferred.

Tests cover construction plus `is("integer")`, that `integer` and `number` are not conflated when passed through the same type function, and that `types.integer` does not satisfy a `number` annotation.