### PR TITLE
Add CMake options for four-wide and double-precision vectors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ endif()
 
 if(LUAU_VECTOR_DOUBLE)
     # Enable double-precision mode for vectors here as requested.
-    target_compile_defitions(Luau.VM PUBLIC "LUA_VECTOR_DOUBLE=1")
+    target_compile_definitions(Luau.VM PUBLIC "LUA_VECTOR_DOUBLE=1")
 endif()
 
 if(LUAU_VECTOR_FOUR_WIDE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ option(LUAU_STATIC_CRT "Link with the static CRT (/MT)" OFF)
 option(LUAU_EXTERN_C "Use extern C for all APIs" OFF)
 option(LUAU_BUILD_SHARED "Build as a shared library" OFF)
 
+# Compile time options for Luau features
+option(LUAU_VECTOR_DOUBLE "Use 64-bit doubles for vector components" OFF)
+option(LUAU_VECTOR_FOUR_WIDE "Enable four-wide mode for vectors, adding a 'w' component" OFF)
+
 if(LUAU_BUILD_SHARED AND NOT LUAU_EXTERN_C)
     message(FATAL_ERROR "LUAU_BUILD_SHARED requires LUAU_EXTERN_C to be ON")
 endif()
@@ -213,6 +217,16 @@ if(LUAU_EXTERN_C)
         target_compile_definitions(Luau.Compiler PUBLIC "LUACODE_API=extern \"C\"")
         target_compile_definitions(Luau.CodeGen PUBLIC "LUACODEGEN_API=extern \"C\"")
     endif()
+endif()
+
+if(LUAU_VECTOR_DOUBLE)
+    # Enable double-precision mode for vectors here as requested.
+    target_compile_defitions(Luau.VM PUBLIC "LUA_VECTOR_DOUBLE=1")
+endif()
+
+if(LUAU_VECTOR_FOUR_WIDE)
+    # Enable four-wide vectors.
+    target_compile_definitions(Luau.VM PUBLIC "LUA_VECTOR_SIZE=4")
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER_EQUAL 1924)


### PR DESCRIPTION
Hi!

I noticed that the CMakeLists.txt didn't have any options to enable four-wide vectors or have them be double precision. 
I don't usually use CMake much but from what I gathered options are better than forcing CMAKE_CXX_FLAGS through commandline, so this PR adds the following:

- `LUAU_VECTOR_DOUBLE ON/OFF`, defaults to off, sets `LUA_VECTOR_DOUBLE=1` in `Luau.VM` if enabled.
- `LUAU_VECTOR_FOUR_WIDE ON/OFF`, default to off, sets `LUA_VECTOR_SIZE=4` in `Luau.VM` if enabled.

Tried it on my end and it appears to be working fine. This would be useful for compilation scripts.

If I missed anything such as another better way to do it, or that makes this PR redundant, please let me know.