### PR TITLE
Correct the flag used for new integer comparison optimization

### DIFF
--- a/CodeGen/src/IrTranslation.cpp
+++ b/CodeGen/src/IrTranslation.cpp
@@ -14,6 +14,7 @@
 
 LUAU_FASTFLAG(LuauCodegenInteger3)
 LUAU_FASTFLAGVARIABLE(LuauCodegenBuilinDeadRange)
+LUAU_FASTFLAGVARIABLE(LuauCodegenIntegerCompare)
 LUAU_FASTFLAG(LuauBackedgeHeapCheck)
 
 namespace Luau
@@ -207,7 +208,7 @@ void translateInstJumpIfEq(IrBuilder& build, const Instruction* pc, int pcpos, b
         build.beginBlock(fallback);
     }
     // fast-path: integer (when both operands are expected to be an integer or are unknown)
-    else if (FFlag::LuauCodegenInteger3 && isExpectedOrUnknownBytecodeType(bcTypes.a, LBC_TYPE_INTEGER) &&
+    else if (FFlag::LuauCodegenInteger3 && FFlag::LuauCodegenIntegerCompare && isExpectedOrUnknownBytecodeType(bcTypes.a, LBC_TYPE_INTEGER) &&
              isExpectedOrUnknownBytecodeType(bcTypes.b, LBC_TYPE_INTEGER))
     {
         IrOp fallback = build.fallbackBlock(pcpos);

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -28,6 +28,7 @@ LUAU_FASTFLAG(LuauCallFeedback)
 LUAU_FASTFLAG(LuauCodegenA64ExitUseCheck)
 LUAU_FASTFLAG(LuauBackedgeHeapCheck)
 LUAU_FASTFLAG(LuauCodegenConstVectorBufferRead)
+LUAU_FASTFLAG(LuauCodegenIntegerCompare)
 
 #define ensureVectorSize3() \
     if constexpr (LUA_VECTOR_SIZE != 3) \
@@ -8495,6 +8496,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "IntegerCompare")
     ScopedFastFlag luauIntegerFastcalls{FFlag::LuauIntegerFastcalls, true};
     ScopedFastFlag LuauCodegenInteger3{FFlag::LuauCodegenInteger3, true};
     ScopedFastFlag luauIntegerType{FFlag::LuauIntegerType2, true};
+    ScopedFastFlag luauCodegenIntegerCompare{FFlag::LuauCodegenIntegerCompare, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(
@@ -8545,6 +8547,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "IntegerCompareConstLhs")
     ScopedFastFlag luauIntegerType{FFlag::LuauIntegerType2, true};
     ScopedFastFlag luauCodegenBufferInteger{FFlag::LuauCodegenBufferInteger, true};
     ScopedFastFlag luauIntegerBufferFastcalls{FFlag::LuauIntegerBufferFastcalls, true};
+    ScopedFastFlag luauCodegenIntegerCompare{FFlag::LuauCodegenIntegerCompare, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(


### PR DESCRIPTION
Missed in review of #2571, should not have been accepted like that.