### PR TITLE
Fix sparse `table.move` still allocating the entire destination range

### DIFF
--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -291,7 +291,8 @@ static int tmove(lua_State* L)
 
         bool sparsemove = DFFlag::LuauTableMoveTimeoutFix && shouldsparsemove(hvalue(L->base), dst, n);
 
-        if (t > 0 && (t - 1) <= dst->sizearray && (t - 1 + n) > dst->sizearray)
+        // sparse moves store the elements in the hash part, so growing the array is not required
+        if (!sparsemove && t > 0 && (t - 1) <= dst->sizearray && (t - 1 + n) > dst->sizearray)
         { // grow the destination table array
             luaH_resizearray(L, dst, t - 1 + n);
         }

--- a/tests/conformance/move.luau
+++ b/tests/conformance/move.luau
@@ -132,8 +132,15 @@ do
 
   -- a huge sparse move starting at destination index 1 must not allocate the full range
   a = {}
+  local bytes = gcinfo()
   table.move({[1] = "first", [10000000] = "last"}, 1, 10000000, 1, a)
+  assert(gcinfo() - bytes < 10000)
   eqT(a, {[1] = "first", [10000000] = "last"})
+
+  -- a sparse move is not bounded by the array size limit as only the moved elements are stored
+  a = {}
+  table.move({[1] = "first", [100000000] = "last"}, 1, 100000000, 1, a)
+  eqT(a, {[1] = "first", [100000000] = "last"})
 
   -- sparse moving on the fringes
   a = table.move({[maxI - 100] = 1, [maxI - 50] = 2, [maxI] = 3},


### PR DESCRIPTION
0.733 added a sparse path to `table.move` for moves where the range is way bigger than the number of elements present. It gets cancelled out when the destination index lands inside the destination's existing array part, which for the usual empty destination table means t = 1.

```lua
local src = {[1] = "first", [10000000] = "last"}
table.move(src, 1, 10000000, 1, {})  -- 158 MB, 96 ms
table.move(src, 1, 10000000, 0, {})  --   5 MB,  3 ms
```

Two elements either way. The only thing that is different is where they land.

Past MAXSIZE it also errors

```lua
local src = {[1] = "first", [100000000] = "last"}
print(pcall(table.move, src, 1, 100000000, 1, {}))  --> false, "table overflow"
print(pcall(table.move, src, 1, 100000000, 0, {}))  --> true
```

This PR fixes that.

Benchmarks:

| destination | flag off                 | flag on                 | flag on with changes from this PR |
|------------------|-------------------------|-------------------------|--------------------------------------------------|
| t = 0             | 5 MB / 604 ms     | 5 MB / 3 ms        | 5 MB / 2 ms                                        |
| t = 1             | 158 MB / 211 ms | 158 MB / 96 ms | 5 MB / 2 ms                                        |
