### PR TITLE
Fix typo in ConstraintSolver comment

### DIFF
--- a/Analysis/src/ConstraintSolver.cpp
+++ b/Analysis/src/ConstraintSolver.cpp
@@ -878,7 +878,7 @@ void ConstraintSolver::bind(NotNull<const Constraint> constraint, TypeId ty, Typ
 
     // This follow shouldn't be needed, but if for some reason we end up
     // with a bound type, we want to also follow it when doing this
-    // occurence check.
+    // occurrence check.
     if (follow(ty) == boundTo)
     {
         auto freshTy = freshType(arena, builtinTypes, constraint->scope, Polarity::Mixed);


### PR DESCRIPTION
Typo in a code comment: `occurence` -> `occurrence`.

`Analysis/src/ConstraintSolver.cpp:881`. It is the only occurrence of that spelling in the tree.
