### PR TITLE
Narrow a register copy's TValue load in constant propagation

### DIFF
--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -28,6 +28,7 @@ LUAU_FLAGVERSION(LuauCodegenLinearNoCall, 2)
 LUAU_FASTFLAGVARIABLE(LuauCodegenSubstituteReplacements)
 LUAU_FASTFLAGVARIABLE(LuauCodegenConstVectorBufferRead)
 LUAU_FASTFLAGVARIABLE(LuauCodegenOriginVerifyMatch)
+LUAU_FASTFLAGVARIABLE(LuauCodegenNarrowRegisterCopy)
 
 namespace Luau
 {
@@ -124,6 +125,23 @@ static uint8_t tryGetTagForTypename(std::string_view name, bool forTypeof)
         return LUA_TBUFFER;
 
     return 0xff;
+}
+
+// Narrower load that reads a TValue's value alone, or NOP when a TValue load cannot be narrowed for this tag.
+// Vectors have none: their value is the whole TValue, so the TValue load already reads exactly the value.
+static IrCmd getNarrowedTValueLoadCmdForTag(uint8_t tag)
+{
+    switch (tag)
+    {
+    case LUA_TBOOLEAN:
+        return IrCmd::LOAD_INT;
+    case LUA_TNUMBER:
+        return IrCmd::LOAD_DOUBLE;
+    case LUA_TINTEGER:
+        return IrCmd::LOAD_INT64;
+    default:
+        return isGCO(tag) ? IrCmd::LOAD_POINTER : IrCmd::NOP;
+    }
 }
 
 // Check if we can treat double as an integer in addition and subtraction
@@ -418,6 +436,10 @@ struct ConstPropState
     {
         if (uint32_t* prevIdx = valueMap.find(inst))
         {
+            // Invalidated entry: the instruction no longer computes this value
+            if (*prevIdx == kInvalidInstIdx)
+                return nullptr;
+
             IrInst& inst = function.instructions[*prevIdx];
 
             // Previous load might have been removed as unused
@@ -1595,6 +1617,32 @@ static void handleBuiltinEffects(ConstPropState& state, LuauBuiltinFunction bfid
     state.invalidateRegistersFrom(firstReturnReg);
 }
 
+// A register copy loads a whole TValue and stores it back, leaving the destination value only in memory so the next
+// read of it returns to the stack. With a known tag the load can read just the value instead.
+static IrCmd tryNarrowVmRegTValueLoad(ConstPropState& state, IrFunction& function, IrBlock& block, uint32_t loadIdx, uint8_t tag)
+{
+    IrCmd loadCmd = getNarrowedTValueLoadCmdForTag(tag);
+
+    if (loadCmd == IrCmd::NOP)
+        return IrCmd::NOP;
+
+    IrInst& load = function.instructions[loadIdx];
+    IrOp vmReg = OP_A(load);
+
+    // The load is rewritten in place, so the asking store has to be its only user
+    if (load.useCount != 1 || function.cfg.captured.regs.test(vmRegOp(vmReg)))
+        return IrCmd::NOP;
+
+    // A later TValue load of this register version must miss, or it would reuse the bare payload as a TValue
+    state.valueMap[state.versionedVmRegLoad(IrCmd::LOAD_TVALUE, vmReg)] = kInvalidInstIdx;
+
+    replace(function, block, loadIdx, IrInst{loadCmd, {vmReg}});
+
+    state.valueMap[state.versionedVmRegLoad(loadCmd, vmReg)] = loadIdx;
+
+    return loadCmd;
+}
+
 static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction& function, IrBlock& block, IrInst& inst, uint32_t index)
 {
     state.instPos++;
@@ -2046,6 +2094,16 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
                 if (IrInst* arg = function.asInstOp(OP_B(inst)); arg && arg->cmd == IrCmd::LOAD_TVALUE && OP_A(arg).kind == IrOpKind::VmReg)
                 {
                     std::tie(activeLoadCmd, activeLoadValue) = state.getPreviousVersionedLoadForTag(tag, OP_A(arg));
+
+                    // With no narrower load of the source to reuse, the copy's own TValue load can become one
+                    if (FFlag::LuauCodegenNarrowRegisterCopy && activeLoadValue == kInvalidInstIdx)
+                    {
+                        if (IrCmd loadCmd = tryNarrowVmRegTValueLoad(state, function, block, OP_B(inst).index, tag); loadCmd != IrCmd::NOP)
+                        {
+                            activeLoadCmd = loadCmd;
+                            activeLoadValue = OP_B(inst).index;
+                        }
+                    }
 
                     if (activeLoadValue != kInvalidInstIdx)
                         value = IrOp{IrOpKind::Inst, activeLoadValue};

--- a/bench/tests/integers/fib_rotate_int64.lua
+++ b/bench/tests/integers/fib_rotate_int64.lua
@@ -1,0 +1,46 @@
+local function prequire(name) local success, result = pcall(require, name); return success and result end
+local bench = script and require(script.Parent.bench_support) or prequire("bench_support") or require("../../bench_support")
+
+function test()
+
+	-- Fibonacci by rotation. Both accumulators stay live across the iteration, so `prev = a` is a copy that has to
+	-- survive, and the exit test splits the loop body so const prop still knows each local's tag past it but not its
+	-- value. That is the case where a copy loads and stores a whole TValue and the next read of the destination has
+	-- to go back to the stack for it.
+	local function fib(rounds: integer): integer
+		local a = 0i
+		local b = 1i
+		local left = rounds
+
+		while true do
+			a = integer.band(a, 0xFFFFFFFFi)
+			b = integer.band(b, 0xFFFFFFFFi)
+
+			if integer.ule(left, 0i) then
+				break
+			end
+			left = integer.sub(left, 1i)
+
+			local prev = a
+			a = b
+			b = integer.add(prev, b)
+		end
+
+		return a
+	end
+
+	local ts0 = os.clock()
+
+	local total = 0i
+	for i = 1, 2000000 do
+		total = integer.add(total, fib(15i))
+	end
+
+	local ts1 = os.clock()
+
+	assert(integer.tonumber(integer.band(total, 0xFFFFFFFFi)) ~= 0)
+
+	return ts1 - ts0
+end
+
+bench.runCode(test, "fib_rotate_int64")

--- a/tests/IrBuilder.test.cpp
+++ b/tests/IrBuilder.test.cpp
@@ -20,6 +20,7 @@ LUAU_FASTFLAG(LuauCodegenSkipDeadPredecessorTags)
 LUAU_FASTFLAG(LuauIntegerLibrary)
 LUAU_FASTFLAG(LuauCodegenSubstituteReplacements)
 LUAU_FASTFLAG(LuauCodegenLinearNoCall)
+LUAU_FASTFLAG(LuauCodegenNarrowRegisterCopy)
 LUAU_FASTFLAG(LuauCodegenOriginVerifyMatch)
 
 using namespace Luau::CodeGen;
@@ -3434,6 +3435,8 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "InvalidateReglinkVersion")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
     IrOp fallback = build.fallbackBlock(0u);
 
@@ -3460,13 +3463,56 @@ TEST_CASE_FIXTURE(IrBuilderFixture, "InvalidateReglinkVersion")
     CHECK("\n" + toString(build.function, IncludeUseInfo::No) == R"(
 bb_0:
    STORE_TAG R2, tstring
-   %1 = LOAD_TVALUE R2, 0i, tstring
-   STORE_TVALUE R1, %1
+   %1 = LOAD_POINTER R2
+   STORE_SPLIT_TVALUE R1, tstring, %1
    %3 = NEW_TABLE 0u, 0u
    STORE_POINTER R2, %3
    STORE_TAG R2, ttable
-   STORE_TVALUE R0, %1
+   STORE_SPLIT_TVALUE R0, tstring, %1
    JUMP bb_fallback_1
+
+bb_fallback_1:
+   RETURN 1u
+
+)");
+}
+
+TEST_CASE_FIXTURE(IrBuilderFixture, "CopyOfKnownTagRegisterLoadsValueOnly")
+{
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
+    IrOp block = build.block(IrBlockKind::Internal);
+    IrOp fallback = build.fallbackBlock(0u);
+
+    build.beginBlock(block);
+
+    // Check establishes the tag without establishing a value, which is the shape a typed argument arrives in
+    IrOp tag = build.inst(IrCmd::LOAD_TAG, build.vmReg(2));
+    build.inst(IrCmd::CHECK_TAG, tag, build.constTag(tnumber), fallback);
+
+    IrOp copy = build.inst(IrCmd::LOAD_TVALUE, build.vmReg(2));
+    build.inst(IrCmd::STORE_TVALUE, build.vmReg(1), copy);
+
+    // A second copy of the same register version must not reuse the retyped load as a TValue
+    IrOp recopy = build.inst(IrCmd::LOAD_TVALUE, build.vmReg(2));
+    build.inst(IrCmd::STORE_TVALUE, build.vmReg(0), recopy);
+
+    build.inst(IrCmd::RETURN, build.constUint(0));
+
+    build.beginBlock(fallback);
+    build.inst(IrCmd::RETURN, build.constUint(1));
+
+    updateUseCounts(build.function);
+    constPropInBlockChains(build);
+
+    CHECK("\n" + toString(build.function, IncludeUseInfo::No) == R"(
+bb_0:
+   %0 = LOAD_TAG R2
+   CHECK_TAG %0, tnumber, bb_fallback_1
+   %2 = LOAD_DOUBLE R2
+   STORE_SPLIT_TVALUE R1, tnumber, %2
+   STORE_SPLIT_TVALUE R0, tnumber, %2
+   RETURN 0u
 
 bb_fallback_1:
    RETURN 1u

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAG(LuauBackedgeHeapCheck)
 LUAU_FASTFLAG(LuauCodegenConstVectorBufferRead)
 LUAU_FASTFLAG(LuauCodegenStoreTagCheck)
 LUAU_FASTFLAG(LuauCodegenIntegerCompare)
+LUAU_FASTFLAG(LuauCodegenNarrowRegisterCopy)
 
 #define ensureVectorSize3() \
     if constexpr (LUA_VECTOR_SIZE != 3) \
@@ -2009,6 +2010,8 @@ bb_bytecode_4:
 
 TEST_CASE_FIXTURE(LoweringFixture, "EntryBlockChecksWithOptional1")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     CHECK_EQ(
         "\n" + getCodegenAssembly(
                    R"(
@@ -2041,8 +2044,8 @@ bb_6:
   INTERRUPT 3u
   RETURN R2, 1i
 bb_bytecode_2:
-  %21 = LOAD_TVALUE R1, 0i, tnumber
-  STORE_TVALUE R2, %21
+  %21 = LOAD_DOUBLE R1
+  STORE_SPLIT_TVALUE R2, tnumber, %21
   INTERRUPT 5u
   RETURN R2, 1i
 )"
@@ -2051,6 +2054,8 @@ bb_bytecode_2:
 
 TEST_CASE_FIXTURE(LoweringFixture, "EntryBlockChecksWithOptional2")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     CHECK_EQ(
         "\n" + getCodegenAssembly(
                    R"(
@@ -2081,8 +2086,8 @@ bb_5:
   INTERRUPT 3u
   RETURN R2, 1i
 bb_bytecode_2:
-  %20 = LOAD_TVALUE R0, 0i, tnumber
-  STORE_TVALUE R2, %20
+  %20 = LOAD_DOUBLE R0
+  STORE_SPLIT_TVALUE R2, tnumber, %20
   INTERRUPT 5u
   RETURN R2, 1i
 )"
@@ -3011,6 +3016,8 @@ bb_linear_11:
 
 TEST_CASE_FIXTURE(LoweringFixture, "LoadEnvReuse")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     CHECK_EQ(
         "\n" + getCodegenAssembly(
                    R"(
@@ -3038,15 +3045,15 @@ bb_bytecode_1:
   %7 = GET_SLOT_NODE_ADDR %6, 0u, K0 ('x')
   CHECK_SLOT_MATCH %7, K0 ('x'), bb_fallback_3
   CHECK_READONLY %6, bb_fallback_3
-  %10 = LOAD_TVALUE R0, 0i, tnumber
-  STORE_TVALUE %7, %10, 0i
+  %10 = LOAD_DOUBLE R0
+  STORE_SPLIT_TVALUE %7, tnumber, %10, 0i
   JUMP bb_linear_9
 bb_linear_9:
   %39 = GET_SLOT_NODE_ADDR %6, 2u, K1 ('y')
   CHECK_SLOT_MATCH %39, K1 ('y'), bb_fallback_5
-  %42 = LOAD_TVALUE R1, 0i, tnumber
-  STORE_TVALUE %39, %42, 0i
-  STORE_TVALUE %7, %42, 0i
+  %42 = LOAD_DOUBLE R1
+  STORE_SPLIT_TVALUE %39, tnumber, %42, 0i
+  STORE_SPLIT_TVALUE %7, tnumber, %42, 0i
   INTERRUPT 6u
   RETURN R0, 0i
 )"
@@ -3885,6 +3892,8 @@ end
 
 TEST_CASE_FIXTURE(LoweringFixture, "ForInManualAnnotation")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     ensureVectorFloat();
 
     ScopedFastFlag callFb{FFlag::LuauCallFeedback, true};
@@ -3924,8 +3933,8 @@ bb_bytecode_1:
   STORE_DOUBLE R1, 0
   STORE_TAG R1, tnumber
   GET_CACHED_IMPORT R2, K1 (nil), 1073741824u ('ipairs'), 2u
-  %8 = LOAD_TVALUE R0, 0i, ttable
-  STORE_TVALUE R3, %8
+  %8 = LOAD_POINTER R0
+  STORE_SPLIT_TVALUE R3, ttable, %8
   INTERRUPT 4u
   SET_SAVEDPC 6u
   CALL R2, 1i, 3i
@@ -4173,6 +4182,8 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "CustomUserdataNamecall1")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     // This test requires runtime component to be present
     if (!Luau::CodeGen::isSupported())
         return;
@@ -4197,19 +4208,18 @@ bb_0:
 bb_2:
   JUMP bb_bytecode_1
 bb_bytecode_1:
-  %6 = LOAD_TVALUE R1, 0i, tuserdata
-  STORE_TVALUE R4, %6
+  %6 = LOAD_POINTER R1
+  STORE_SPLIT_TVALUE R4, tuserdata, %6
   %10 = LOAD_POINTER R0
   CHECK_USERDATA_TAG %10, 12i, exit(1)
-  %14 = LOAD_POINTER R1
-  CHECK_USERDATA_TAG %14, 12i, exit(1)
+  CHECK_USERDATA_TAG %6, 12i, exit(1)
   %16 = BUFFER_READF32 %10, 0i, tuserdata
-  %17 = BUFFER_READF32 %14, 0i, tuserdata
+  %17 = BUFFER_READF32 %6, 0i, tuserdata
   %18 = FLOAT_TO_NUM %16
   %19 = FLOAT_TO_NUM %17
   %20 = MUL_NUM %18, %19
   %21 = BUFFER_READF32 %10, 4i, tuserdata
-  %22 = BUFFER_READF32 %14, 4i, tuserdata
+  %22 = BUFFER_READF32 %6, 4i, tuserdata
   %23 = FLOAT_TO_NUM %21
   %24 = FLOAT_TO_NUM %22
   %25 = MUL_NUM %23, %24
@@ -4225,6 +4235,8 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "CustomUserdataNamecall2")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     // This test requires runtime component to be present
     if (!Luau::CodeGen::isSupported())
         return;
@@ -4249,19 +4261,18 @@ bb_0:
 bb_2:
   JUMP bb_bytecode_1
 bb_bytecode_1:
-  %6 = LOAD_TVALUE R1, 0i, tuserdata
-  STORE_TVALUE R4, %6
+  %6 = LOAD_POINTER R1
+  STORE_SPLIT_TVALUE R4, tuserdata, %6
   %10 = LOAD_POINTER R0
   CHECK_USERDATA_TAG %10, 12i, exit(1)
-  %14 = LOAD_POINTER R1
-  CHECK_USERDATA_TAG %14, 12i, exit(1)
+  CHECK_USERDATA_TAG %6, 12i, exit(1)
   %16 = BUFFER_READF32 %10, 0i, tuserdata
-  %17 = BUFFER_READF32 %14, 0i, tuserdata
+  %17 = BUFFER_READF32 %6, 0i, tuserdata
   %18 = FLOAT_TO_NUM %16
   %19 = FLOAT_TO_NUM %17
   %20 = MIN_NUM %18, %19
   %21 = BUFFER_READF32 %10, 4i, tuserdata
-  %22 = BUFFER_READF32 %14, 4i, tuserdata
+  %22 = BUFFER_READF32 %6, 4i, tuserdata
   %23 = FLOAT_TO_NUM %21
   %24 = FLOAT_TO_NUM %22
   %25 = MIN_NUM %23, %24
@@ -4441,6 +4452,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "CustomUserdataMapping")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
     ScopedFastFlag callFb{FFlag::LuauCallFeedback, true};
     ScopedFastFlag emitCallFb{FFlag::LuauEmitCallFeedback, true};
 
@@ -4468,8 +4480,8 @@ bb_2:
 bb_bytecode_1:
   implicit CHECK_SAFE_ENV exit(0)
   GET_CACHED_IMPORT R1, K1 (nil), 1073741824u ('print'), 1u
-  %6 = LOAD_TVALUE R0, 0i, tuserdata
-  STORE_TVALUE R2, %6
+  %6 = LOAD_POINTER R0
+  STORE_SPLIT_TVALUE R2, tuserdata, %6
   GET_CACHED_IMPORT R3, K4 (nil), 2149583872u ('vec2'.'create'), 4u
   STORE_DOUBLE R4, 0
   STORE_TAG R4, tnumber
@@ -5361,6 +5373,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveLoopRangeBase")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
     ScopedFastFlag callFb{FFlag::LuauCallFeedback, true};
     ScopedFastFlag emitCallFb{FFlag::LuauEmitCallFeedback, true};
     ScopedFastFlag luauBackedgeHeapCheck{FFlag::LuauBackedgeHeapCheck, true};
@@ -5392,8 +5405,8 @@ bb_bytecode_1:
   STORE_DOUBLE R5, 0
   STORE_TAG R5, tnumber
   GET_CACHED_IMPORT R6, K3 (nil), 2148534272u ('buffer'.'len'), 3u
-  %12 = LOAD_TVALUE R0, 0i, tbuffer
-  STORE_TVALUE R7, %12
+  %12 = LOAD_POINTER R0
+  STORE_SPLIT_TVALUE R7, tbuffer, %12
   INTERRUPT 5u
   SET_SAVEDPC 7u
   CALL R6, 1i, 1i
@@ -6334,6 +6347,8 @@ bb_bytecode_0:
 
 TEST_CASE_FIXTURE(LoweringFixture, "OldStyleConditional")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     // TODO: opportunity - this can be done in two SELECT_IF_TRUTHY, but we cannot match such complex sequences right now
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -6354,12 +6369,12 @@ bb_4:
 bb_bytecode_1:
   JUMP_IF_FALSY R0, bb_bytecode_2, bb_5
 bb_5:
-  %9 = LOAD_TVALUE R1, 0i, tnumber
-  STORE_TVALUE R3, %9
+  %9 = LOAD_DOUBLE R1
+  STORE_SPLIT_TVALUE R3, tnumber, %9
   JUMP bb_bytecode_3
 bb_bytecode_2:
-  %12 = LOAD_TVALUE R2, 0i, tnumber
-  STORE_TVALUE R3, %12
+  %12 = LOAD_DOUBLE R2
+  STORE_SPLIT_TVALUE R3, tnumber, %12
   JUMP bb_bytecode_3
 bb_bytecode_3:
   CHECK_TAG R3, tnumber, exit(4)
@@ -6375,6 +6390,8 @@ bb_bytecode_3:
 
 TEST_CASE_FIXTURE(LoweringFixture, "NewStyleConditional")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
+
     // TODO: opportunity - this can be done in one SELECT_IF_TRUTHY, but this is also hard to detect in current system
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -6395,12 +6412,12 @@ bb_4:
 bb_bytecode_1:
   JUMP_IF_FALSY R0, bb_bytecode_2, bb_5
 bb_5:
-  %9 = LOAD_TVALUE R1, 0i, tnumber
-  STORE_TVALUE R3, %9
+  %9 = LOAD_DOUBLE R1
+  STORE_SPLIT_TVALUE R3, tnumber, %9
   JUMP bb_bytecode_3
 bb_bytecode_2:
-  %12 = LOAD_TVALUE R2, 0i, tnumber
-  STORE_TVALUE R3, %12
+  %12 = LOAD_DOUBLE R2
+  STORE_SPLIT_TVALUE R3, tnumber, %12
   JUMP bb_bytecode_3
 bb_bytecode_3:
   CHECK_TAG R3, tnumber, exit(4)
@@ -7605,6 +7622,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "LoopStepDetection1")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
     ScopedFastFlag luauBackedgeHeapCheck{FFlag::LuauBackedgeHeapCheck, true};
 
     assemblyOptions.includeRegFlowInfo = Luau::CodeGen::IncludeRegFlowInfo::Yes;
@@ -7639,12 +7657,11 @@ bb_bytecode_1:
   STORE_TAG R1, tnumber
   STORE_DOUBLE R4, 1
   STORE_TAG R4, tnumber
-  %8 = LOAD_TVALUE R0, 0i, tnumber
-  STORE_TVALUE R2, %8
+  %8 = LOAD_DOUBLE R0
+  STORE_SPLIT_TVALUE R2, tnumber, %8
   STORE_DOUBLE R3, 1
   STORE_TAG R3, tnumber
-  %16 = LOAD_DOUBLE R0
-  JUMP_CMP_NUM 1, %16, not_le, bb_bytecode_3, bb_bytecode_2
+  JUMP_CMP_NUM 1, %8, not_le, bb_bytecode_3, bb_bytecode_2
 bb_bytecode_2:
 ; in regs: R1, R2, R3, R4
 ; out regs: R1, R2, R3, R4
@@ -8494,6 +8511,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "BufferWriteChecksExtraArgs")
 {
+    ScopedFastFlag splitRegisterCopy{FFlag::LuauCodegenNarrowRegisterCopy, true};
     ScopedFastFlag luauCodegenStoreTagCheck{FFlag::LuauCodegenStoreTagCheck, true};
 
     CHECK_EQ(
@@ -8519,22 +8537,20 @@ bb_2:
   JUMP bb_bytecode_1
 bb_bytecode_1:
   implicit CHECK_SAFE_ENV exit(0)
-  %6 = LOAD_TVALUE R0, 0i, tbuffer
-  STORE_TVALUE R4, %6
-  %8 = LOAD_TVALUE R1, 0i, tnumber
-  STORE_TVALUE R5, %8
+  %6 = LOAD_POINTER R0
+  STORE_SPLIT_TVALUE R4, tbuffer, %6
+  %8 = LOAD_DOUBLE R1
+  STORE_SPLIT_TVALUE R5, tnumber, %8
   %10 = LOAD_TVALUE R2
   STORE_TVALUE R6, %10
   STORE_DOUBLE R7, 0
   STORE_TAG R7, tnumber
   CHECK_TAG R2, tnumber, exit(5)
-  %21 = LOAD_POINTER R0
-  %22 = LOAD_DOUBLE R1
-  %23 = NUM_TO_INT %22
-  CHECK_BUFFER_LEN %21, %23, 0i, 4i, undef, exit(5)
+  %23 = NUM_TO_INT %8
+  CHECK_BUFFER_LEN %6, %23, 0i, 4i, undef, exit(5)
   %25 = LOAD_DOUBLE R2
   %26 = NUM_TO_UINT %25
-  BUFFER_WRITEI32 %21, %23, %26, tbuffer
+  BUFFER_WRITEI32 %6, %23, %26, tbuffer
   ADJUST_STACK_TO_REG R3, 0i
   INTERRUPT 8u
   RETURN R3, -1i


### PR DESCRIPTION
In native codegen a register copy loads a whole TValue and stores it back, so the value lives only in memory and the next read of it returns to the stack, which a wide store cannot forward to a narrower load.

Constant propagation already folds such a copy into `STORE_SPLIT_TVALUE` when a narrower load of the source exists. This lets the copy make one itself. Vectors are skipped, since their value is the whole TValue.

Behind `FFlag::LuauCodegenNarrowRegisterCopy`.

The sentinel in `getPreviousInstIndex` needs a second opinion. Rewriting a load in place changes what it computes, but the value map still points at it, and nothing invalidates that entry because it is keyed on register version and the register never changed. A new test `CopyOfKnownTagRegisterLoadsValueOnly` covers it.

### Benchmark

Adds `bench/tests/integers/fib_rotate_int64.lua`, where both accumulators stay live and the exit test splits the loop body. Ran on 11th Gen Intel Core i7-1165G7, x64.

| | off | on | |
|---|---|---|---|
| cycles | 25,133,884,657 | 15,830,679,888 | 1.59x |
| store forwarding stalls | 1,520,592,314 | 24,041,842 | 63x fewer |
| instructions | 50,599,549,850 | 50,647,552,949 | +0.095% |
| bench.py min | 241.2 ms | 152.2 ms | 1.58x faster |

Instructions rise because the split store is two against one. The gain is the stalls.

Across all 151 bench.py tests the geomean is flat at -0.03% and only this one moves. Four tests compile identically under both settings and still report -2.2% to +3.1%, so nothing else clears the noise.