### PR TITLE
Check argument types of calls through a __call metamethod

### DIFF
--- a/Analysis/src/OverloadResolver.cpp
+++ b/Analysis/src/OverloadResolver.cpp
@@ -13,6 +13,7 @@
 #include "Luau/Unifier2.h"
 
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauFixCallMetamethodErrorReporting)
 
 namespace Luau
 {
@@ -299,6 +300,14 @@ void OverloadResolver::reportErrors(
 ) const
 {
     std::optional<size_t> argumentIndex = getArgumentIndex(reason.subPath, fnTy);
+
+    // A variadic parameter has no index of its own, so the subPath stops at the tail. The
+    // argument that failed against it is the one the superPath names.
+    if (FFlag::LuauFixCallMetamethodErrorReporting && !argumentIndex)
+    {
+        const TypeId given = arena->addType(FunctionType{argPack, builtinTypes->anyTypePack});
+        argumentIndex = getArgumentIndex(reason.superPath, given);
+    }
 
     Location argLocation;
     // If the Nth argument directly corresponds to a term in the AST, use its location.

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -1559,6 +1559,35 @@ static void reportAvailableOverloads(ErrorVec& errors, Location location, const 
     errors.emplace_back(location, moduleName, ExtraInformation{s.str()});
 }
 
+// The function a call invokes, and how many of its parameters are filled before the
+// arguments written at the call site. A callable table invokes its __call metamethod, which
+// takes the callee as its first argument.
+struct CalleeSignature
+{
+    const FunctionType* fn = nullptr;
+    size_t leadingParams = 0;
+};
+
+static CalleeSignature getCalleeSignature(NotNull<BuiltinTypes> builtinTypes, TypeId fnTy, AstExprCall* call)
+{
+    if (const FunctionType* fn = get<FunctionType>(fnTy))
+        return {fn, call->self ? 1u : 0u};
+
+    // A method call already fills the first parameter with the receiver, so a callable table
+    // reached that way would need two and is left alone.
+    if (call->self)
+        return {};
+
+    ErrorVec ignored;
+    if (std::optional<TypeId> callMetamethod = findMetatableEntry(builtinTypes, ignored, fnTy, "__call", call->func->location))
+    {
+        if (const FunctionType* fn = get<FunctionType>(follow(*callMetamethod)))
+            return {fn, 1};
+    }
+
+    return {};
+}
+
 void TypeChecker2::visitCall(AstExprCall* call)
 {
     TypePack args;
@@ -1631,9 +1660,11 @@ void TypeChecker2::visitCall(AstExprCall* call)
 
     // FIXME: Similar to bidirectional inference prior, this does not support
     // overloaded functions nor generic typeArguments (yet).
-    if (auto fty = get<FunctionType>(fnTy); fty && fty->generics.empty() && fty->genericPacks.empty() && call->args.size > 0)
+    const CalleeSignature callee = getCalleeSignature(builtinTypes, fnTy, call);
+
+    if (const FunctionType* fty = callee.fn; fty && fty->generics.empty() && fty->genericPacks.empty() && call->args.size > 0)
     {
-        size_t selfOffset = call->self ? 1 : 0;
+        const size_t selfOffset = callee.leadingParams;
 
         std::vector<TypeId> paramsHead = extendTypePack(*module->internalTypes, builtinTypes, fty->argTypes, call->args.size + selfOffset).head;
 
@@ -1745,10 +1776,21 @@ void TypeChecker2::visitCall(AstExprCall* call)
     {
         for (const auto& [ty, reasons] : result2.incompatibleOverloads)
         {
+            // A metamethod is reasoned about with the callee prepended, so reporting
+            // traverses that same pack. Otherwise the lookup misses and the error is lost.
+            TypePackId reportedArgs = argsPack;
+            std::vector<AstExpr*> reportedExprs = argExprs;
+
+            if (result2.metamethods.contains(ty))
+            {
+                reportedArgs = module->internalTypes->addTypePack(TypePack{{fnTy}, argsPack});
+                reportedExprs.insert(reportedExprs.begin(), call->func);
+            }
+
             if (const SubtypingReasonings* sr = get_if<SubtypingReasonings>(&reasons))
             {
                 for (const SubtypingReasoning& reason : *sr)
-                    resolver.reportErrors(module->errors, ty, call->func->location, module->name, argsPack, argExprs, reason);
+                    resolver.reportErrors(module->errors, ty, call->func->location, module->name, reportedArgs, reportedExprs, reason);
             }
             else if (const auto errorVec = get_if<ErrorVec>(&reasons))
             {

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -35,6 +35,7 @@
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 
 LUAU_FASTFLAG(LuauIntegerType2)
+LUAU_FASTFLAGVARIABLE(LuauFixCallMetamethodErrorReporting)
 LUAU_FASTFLAGVARIABLE(LuauCheckFunctionStatementTypes)
 LUAU_FASTFLAGVARIABLE(LuauPropertyModifierMismatchErrors)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
@@ -1559,35 +1560,6 @@ static void reportAvailableOverloads(ErrorVec& errors, Location location, const 
     errors.emplace_back(location, moduleName, ExtraInformation{s.str()});
 }
 
-// The function a call invokes, and how many of its parameters are filled before the
-// arguments written at the call site. A callable table invokes its __call metamethod, which
-// takes the callee as its first argument.
-struct CalleeSignature
-{
-    const FunctionType* fn = nullptr;
-    size_t leadingParams = 0;
-};
-
-static CalleeSignature getCalleeSignature(NotNull<BuiltinTypes> builtinTypes, TypeId fnTy, AstExprCall* call)
-{
-    if (const FunctionType* fn = get<FunctionType>(fnTy))
-        return {fn, call->self ? 1u : 0u};
-
-    // A method call already fills the first parameter with the receiver, so a callable table
-    // reached that way would need two and is left alone.
-    if (call->self)
-        return {};
-
-    ErrorVec ignored;
-    if (std::optional<TypeId> callMetamethod = findMetatableEntry(builtinTypes, ignored, fnTy, "__call", call->func->location))
-    {
-        if (const FunctionType* fn = get<FunctionType>(follow(*callMetamethod)))
-            return {fn, 1};
-    }
-
-    return {};
-}
-
 void TypeChecker2::visitCall(AstExprCall* call)
 {
     TypePack args;
@@ -1660,11 +1632,9 @@ void TypeChecker2::visitCall(AstExprCall* call)
 
     // FIXME: Similar to bidirectional inference prior, this does not support
     // overloaded functions nor generic typeArguments (yet).
-    const CalleeSignature callee = getCalleeSignature(builtinTypes, fnTy, call);
-
-    if (const FunctionType* fty = callee.fn; fty && fty->generics.empty() && fty->genericPacks.empty() && call->args.size > 0)
+    if (auto fty = get<FunctionType>(fnTy); fty && fty->generics.empty() && fty->genericPacks.empty() && call->args.size > 0)
     {
-        const size_t selfOffset = callee.leadingParams;
+        size_t selfOffset = call->self ? 1 : 0;
 
         std::vector<TypeId> paramsHead = extendTypePack(*module->internalTypes, builtinTypes, fty->argTypes, call->args.size + selfOffset).head;
 
@@ -1781,7 +1751,7 @@ void TypeChecker2::visitCall(AstExprCall* call)
             TypePackId reportedArgs = argsPack;
             std::vector<AstExpr*> reportedExprs = argExprs;
 
-            if (result2.metamethods.contains(ty))
+            if (FFlag::LuauFixCallMetamethodErrorReporting && result2.metamethods.contains(ty))
             {
                 reportedArgs = module->internalTypes->addTypePack(TypePack{{fnTy}, argsPack});
                 reportedExprs.insert(reportedExprs.begin(), call->func);

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -1750,28 +1750,45 @@ void TypeChecker2::visitCall(AstExprCall* call)
     {
         for (const auto& [ty, reasons] : result2.incompatibleOverloads)
         {
-            // A metamethod is reasoned about with the callee prepended, so reporting
-            // traverses that same pack. Otherwise the lookup misses and the error is lost.
-            TypePackId reportedArgs = argsPack;
-            std::vector<AstExpr*> reportedExprs = argExprs;
+            if (FFlag::LuauFixCallMetamethodErrorReporting)
+            {
+                // A metamethod is reasoned about with the callee prepended, so reporting
+                // traverses that same pack. Otherwise the lookup misses and the error is lost.
+                TypePackId reportedArgs = argsPack;
+                std::vector<AstExpr*> reportedExprs = argExprs;
 
-            if (FFlag::LuauFixCallMetamethodErrorReporting && result2.metamethods.contains(ty))
-            {
-                reportedArgs = module->internalTypes->addTypePack(TypePack{{fnTy}, argsPack});
-                reportedExprs.insert(reportedExprs.begin(), call->func);
-            }
+                if (result2.metamethods.contains(ty))
+                {
+                    reportedArgs = module->internalTypes->addTypePack(TypePack{{fnTy}, argsPack});
+                    reportedExprs.insert(reportedExprs.begin(), call->func);
+                }
 
-            if (const SubtypingReasonings* sr = get_if<SubtypingReasonings>(&reasons))
-            {
-                for (const SubtypingReasoning& reason : *sr)
-                    resolver.reportErrors(module->errors, ty, call->func->location, module->name, reportedArgs, reportedExprs, reason);
-            }
-            else if (const auto errorVec = get_if<ErrorVec>(&reasons))
-            {
-                reportErrors(*errorVec);
+                if (const SubtypingReasonings* sr = get_if<SubtypingReasonings>(&reasons))
+                {
+                    for (const SubtypingReasoning& reason : *sr)
+                        resolver.reportErrors(module->errors, ty, call->func->location, module->name, reportedArgs, reportedExprs, reason);
+                }
+                else if (const auto errorVec = get_if<ErrorVec>(&reasons))
+                {
+                    reportErrors(*errorVec);
+                }
+                else
+                    LUAU_ASSERT(!"Unreachable");
             }
             else
-                LUAU_ASSERT(!"Unreachable");
+            {
+                if (const SubtypingReasonings* sr = get_if<SubtypingReasonings>(&reasons))
+                {
+                    for (const SubtypingReasoning& reason : *sr)
+                        resolver.reportErrors(module->errors, ty, call->func->location, module->name, argsPack, argExprs, reason);
+                }
+                else if (const auto errorVec = get_if<ErrorVec>(&reasons))
+                {
+                    reportErrors(*errorVec);
+                }
+                else
+                    LUAU_ASSERT(!"Unreachable");
+            }
         }
 
         return;

--- a/tests/TypeInfer.classes.test.cpp
+++ b/tests/TypeInfer.classes.test.cpp
@@ -323,7 +323,7 @@ TEST_CASE_FIXTURE(ClassesFixture, "isinstance_refines_imported_class")
     fileResolver.source["game/B"] = R"(
         local A = require(game.A)
 
-        local x : unknown = (A.Point {} ) :: any
+        local x : unknown = (A.Point { x = 0 } ) :: any
         if class.isinstance(x, A.Point) then
             local y = x
         end
@@ -348,7 +348,7 @@ TEST_CASE_FIXTURE(ClassesFixture, "isinstance_refines_imported_class_but_not_a_c
     fileResolver.source["game/B"] = R"(
         local A = require(game.A)
 
-        local x : unknown = (A.Point {} ) :: any
+        local x : unknown = (A.Point { x = 0 } ) :: any
         if class.isinstance(x, A.notAPoint) then
             local y = x
         end

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -21,6 +21,7 @@ LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTINT(LuauTarjanChildLimit)
 LUAU_FASTFLAG(LuauCheckFunctionStatementTypes)
+LUAU_FASTFLAG(LuauFixCallMetamethodErrorReporting)
 LUAU_FASTFLAG(LuauBidirectionalInferenceVariadics)
 LUAU_FASTFLAG(LuauBidirectionalInferenceBetterLambdaHandling)
 LUAU_FASTFLAG(LuauHigherOrderGenericInference)
@@ -2377,6 +2378,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "attempt_to_call_an_intersection_of_tables_wi
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_checks_argument_types")
 {
+    ScopedFastFlag _{FFlag::LuauFixCallMetamethodErrorReporting, true};
+
     CheckResult result = check(R"(
         type Callable = typeof(setmetatable({}, {} :: { __call: (Callable, number) -> string }))
         local f = (nil :: any) :: Callable
@@ -2391,6 +2394,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_checks_argument_types")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_checks_variadic_argument_types")
 {
+    ScopedFastFlag _{FFlag::LuauFixCallMetamethodErrorReporting, true};
+
     CheckResult result = check(R"(
         type Callable = typeof(setmetatable({}, {} :: { __call: (Callable, ...number) -> () }))
         local f = (nil :: any) :: Callable

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -2408,6 +2408,46 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_checks_variadic_argument_typ
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 }
 
+// A variadic parameter has no index of its own, so the argument index is recovered from
+// the superPath. Without that, the error lands on the last argument rather than the bad one.
+TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_variadic_blames_the_offending_argument")
+{
+    ScopedFastFlag _{FFlag::LuauFixCallMetamethodErrorReporting, true};
+
+    CheckResult result = check(R"(
+        type Callable = typeof(setmetatable({}, {} :: { __call: (Callable, ...number) -> () }))
+        local f = (nil :: any) :: Callable
+
+        f(1, "wrong", 3)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK(get<TypeMismatch>(result.errors[0]));
+
+    // Check if the type error was reported on the second argument ("wrong")
+    CHECK_EQ(result.errors[0].location, Location{{4, 13}, {4, 20}});
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_variadic_blames_each_offending_argument")
+{
+    ScopedFastFlag _{FFlag::LuauFixCallMetamethodErrorReporting, true};
+
+    CheckResult result = check(R"(
+        type Callable = typeof(setmetatable({}, {} :: { __call: (Callable, ...number) -> () }))
+        local f = (nil :: any) :: Callable
+
+        f("a", 2, "b")
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(2, result);
+
+    CHECK(get<TypeMismatch>(result.errors[0]));
+    CHECK_EQ(result.errors[0].location, Location{{4, 18}, {4, 21}});
+
+    CHECK(get<TypeMismatch>(result.errors[1]));
+    CHECK_EQ(result.errors[1].location, Location{{4, 10}, {4, 13}});
+}
+
 TEST_CASE_FIXTURE(Fixture, "generic_packs_are_not_variadic")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -2375,6 +2375,33 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "attempt_to_call_an_intersection_of_tables_wi
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_checks_argument_types")
+{
+    CheckResult result = check(R"(
+        type Callable = typeof(setmetatable({}, {} :: { __call: (Callable, number) -> string }))
+        local f = (nil :: any) :: Callable
+
+        local ok: string = f(1)
+        local bad: string = f("wrong")
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK(get<TypeMismatch>(result.errors[0]));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_checks_variadic_argument_types")
+{
+    CheckResult result = check(R"(
+        type Callable = typeof(setmetatable({}, {} :: { __call: (Callable, ...number) -> () }))
+        local f = (nil :: any) :: Callable
+
+        f(1, 2, 3)
+        f(1, "wrong")
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+}
+
 TEST_CASE_FIXTURE(Fixture, "generic_packs_are_not_variadic")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -13,6 +13,8 @@
 #include "ScopedFlags.h"
 #include "doctest.h"
 
+#include <algorithm>
+
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
@@ -2441,11 +2443,23 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "call_metamethod_variadic_blames_each_offendi
 
     LUAU_REQUIRE_ERROR_COUNT(2, result);
 
-    CHECK(get<TypeMismatch>(result.errors[0]));
-    CHECK_EQ(result.errors[0].location, Location{{4, 18}, {4, 21}});
+    // The two errors arrive in an order that differs between standard libraries, so sort them by
+    // location first, which is what the frontend does before anyone sees them.
+    std::vector<TypeError> errors = result.errors;
+    std::sort(
+        errors.begin(),
+        errors.end(),
+        [](const TypeError& lhs, const TypeError& rhs)
+        {
+            return lhs.location.begin < rhs.location.begin;
+        }
+    );
 
-    CHECK(get<TypeMismatch>(result.errors[1]));
-    CHECK_EQ(result.errors[1].location, Location{{4, 10}, {4, 13}});
+    CHECK(get<TypeMismatch>(errors[0]));
+    CHECK_EQ(errors[0].location, Location{{4, 10}, {4, 13}});
+
+    CHECK(get<TypeMismatch>(errors[1]));
+    CHECK_EQ(errors[1].location, Location{{4, 18}, {4, 21}});
 }
 
 TEST_CASE_FIXTURE(Fixture, "generic_packs_are_not_variadic")


### PR DESCRIPTION
A `__call` metamethod receives the callee as its first argument, and argument checking does not account for that.

```luau
local t = setmetatable({}, {
	__call = function(self, x: number) end,
})

t("hello")       -- no error
t("hello", "hi") -- error on "hi", expected number got string
t("hello", 5)    -- error on 5, expected number got number
```

`x` receives `"hello"`, so all three lines should point there. Now they do. Code whose metamethod omits `self` still errors, but names the callee instead of the first argument, since that is the value the parameter receives.

Classes are callable tables, so constructor arguments are checked too. That needed a small change to two fixtures in `TypeInfer.classes.test.cpp` which built `Point` without its required field.
