### PR TITLE
Benchmarks: pass new `--solver` flag to `luau-analyze`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,12 +61,12 @@ jobs:
           filter() {
             awk '/.*I\s+refs:\s+[0-9,]+/ {gsub(",", "", $4); X=$4} END {print "SUCCESS: '$1' : " X/1e7 "ms +/- 0% on luau-analyze"}'
           }
-          valgrind --tool=callgrind ./luau-analyze --mode=nonstrict bench/other/LuauPolyfillMap.lua 2>&1 | filter map-nonstrict | tee -a analyze-output.txt
-          valgrind --tool=callgrind ./luau-analyze --mode=strict bench/other/LuauPolyfillMap.lua 2>&1 | filter map-strict | tee -a analyze-output.txt
-          valgrind --tool=callgrind ./luau-analyze --mode=strict --fflags=LuauSolverV2 bench/other/LuauPolyfillMap.lua 2>&1 | filter map-dcr | tee -a analyze-output.txt
-          valgrind --tool=callgrind ./luau-analyze --mode=nonstrict bench/other/regex.lua 2>&1 | filter regex-nonstrict | tee -a analyze-output.txt
-          valgrind --tool=callgrind ./luau-analyze --mode=strict bench/other/regex.lua 2>&1 | filter regex-strict | tee -a analyze-output.txt
-          valgrind --tool=callgrind ./luau-analyze --mode=strict --fflags=LuauSolverV2 bench/other/regex.lua 2>&1 | filter regex-dcr | tee -a analyze-output.txt
+          valgrind --tool=callgrind ./luau-analyze --mode=nonstrict --solver=old bench/other/LuauPolyfillMap.lua 2>&1 | filter map-nonstrict | tee -a analyze-output.txt
+          valgrind --tool=callgrind ./luau-analyze --mode=strict --solver=old bench/other/LuauPolyfillMap.lua 2>&1 | filter map-strict | tee -a analyze-output.txt
+          valgrind --tool=callgrind ./luau-analyze --mode=strict --solver=new bench/other/LuauPolyfillMap.lua 2>&1 | filter map-dcr | tee -a analyze-output.txt
+          valgrind --tool=callgrind ./luau-analyze --mode=nonstrict --solver=old bench/other/regex.lua 2>&1 | filter regex-nonstrict | tee -a analyze-output.txt
+          valgrind --tool=callgrind ./luau-analyze --mode=strict --solver=old bench/other/regex.lua 2>&1 | filter regex-strict | tee -a analyze-output.txt
+          valgrind --tool=callgrind ./luau-analyze --mode=strict --solver=new bench/other/regex.lua 2>&1 | filter regex-dcr | tee -a analyze-output.txt
 
       - name: Run benchmark (compile)
         run: |


### PR DESCRIPTION
In 0.721, we introduced a new `--solver` flag to `luau-analyze` with `--solver=new` being the default. Because of this, all the old solver benchmarks appear to have had sizable regressions in this version ([graphs](https://perf.luau-lang.org/?analyze)), but this is actually because the solver mode was changed under the hood.

This PR hardcodes the solver mode, and I'll put a follow-up in the [benchmark data repository](https://github.com/luau-lang/benchmark-data) to delete these wrong entries (probably just setting them to 0).