### PR TITLE
Allow `next` to accept read-only indexers

### DIFF
--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -25,6 +25,7 @@
 #include <string_view>
 
 LUAU_FASTFLAG(LuauCyclicRequireTypeInference)
+LUAU_FASTFLAGVARIABLE(LuauNextReadOnlyIndexer)
 LUAU_FASTFLAG(LuauUdtfErrorHandling)
 
 /** FIXME: Many of these type definitions are not quite completely accurate.
@@ -401,15 +402,23 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
         metatableTy->props["__div"] = {makeIntersection(arena, mulOverloads)};
         metatableTy->props["__idiv"] = {makeIntersection(arena, mulOverloads)};
     }
-
+    
     // next<K, V>(t: Table<K, V>, i: K?) -> (K?, V)
-    TypePackId nextArgsTypePack = arena.addTypePack(TypePack{{mapOfKtoV, makeOption(builtinTypes, arena, genericK)}});
+    TypePackId mutableNextArgsTypePack = arena.addTypePack(TypePack{{mapOfKtoV, makeOption(builtinTypes, arena, genericK)}});
+    TypePackId nextArgsTypePack = mutableNextArgsTypePack;
+    
+    if (FFlag::LuauNextReadOnlyIndexer && frontend.getLuauSolverMode() == SolverMode::New)
+    {
+        TypeId readOnlyMapOfKtoV = arena.addType(TableType{{}, TableIndexer(genericK, genericV, /* isReadOnly */ true), globals.globalScope->level, TableState::Generic});
+        nextArgsTypePack = arena.addTypePack(TypePack{{readOnlyMapOfKtoV, makeOption(builtinTypes, arena, genericK)}});
+    }
+    
     TypePackId nextRetsTypePack = arena.addTypePack(TypePack{{makeOption(builtinTypes, arena, genericK), genericV}});
     addGlobalBinding(globals, "next", arena.addType(FunctionType{{genericK, genericV}, {}, nextArgsTypePack, nextRetsTypePack}), "@luau");
-
+    
     TypePackId pairsArgsTypePack = arena.addTypePack({mapOfKtoV});
-
-    TypeId pairsNext = arena.addType(FunctionType{nextArgsTypePack, nextRetsTypePack});
+    
+    TypeId pairsNext = arena.addType(FunctionType{mutableNextArgsTypePack, nextRetsTypePack});
     TypePackId pairsReturnTypePack = arena.addTypePack(TypePack{{pairsNext, mapOfKtoV, builtinTypes->nilType}});
 
     // pairs<K, V>(t: Table<K, V>) -> ((Table<K, V>, K?) -> (K, V), Table<K, V>, nil)

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -12,6 +12,7 @@ using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauNewTypePathErrorMessages)
+LUAU_FASTFLAG(LuauNextReadOnlyIndexer)
 
 TEST_SUITE_BEGIN("BuiltinTests");
 
@@ -69,6 +70,30 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "next_iterator_should_infer_types_and_type_ch
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "next_accepts_read_only_indexers")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauNextReadOnlyIndexer, true},
+    };
+
+    CheckResult result = check(R"(
+        local array: { read string } = { "foo", "bar" }
+        local arrayKey: number?, arrayValue: string = next(array)
+
+        local map: { read [string]: number } = { foo = 1 }
+        local mapKey: string?, mapValue: number = next(map)
+
+        local mutableMap: { [string]: number } = { foo = 1 }
+        local mutableKey: string?, mutableValue: number = next(mutableMap)
+
+        local _, state = pairs(mutableMap)
+        state["foo"] = 2
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "pairs_iterator_should_infer_types_and_type_check")


### PR DESCRIPTION
Fixes #2627.

`next` only reads from its table argument, but its current builtin type requires a read-write indexer. This causes tables with read-only indexers to be rejected.

This changes the ```next``` argument type to use a read-only indexer behind ```LuauNextReadOnlyIndexer``` for the new solver.

The mutable argument type used by the iterator returned from ```pairs``` is kept separate, so existing ```pairs``` behavior remains unchanged.

Adds coverage for read-only arrays and dictionaries, mutable inputs, and preservation of the mutable ```pairs``` state table.

No runtime behavior changes.