### PR TITLE
Rename `luaL_typename` to `luaL_typeof`

### DIFF
--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -561,7 +561,7 @@ static int createSingleton(lua_State* L)
     }
 
     if (FFlag::LuauUdtfCreateSingletonFixErrorMessage)
-        luaL_error(L, "types.singleton: can't create a singleton from a %s", luaL_typename(L, 1));
+        luaL_error(L, "types.singleton: can't create a singleton from a %s", luaL_typeof(L, 1));
     else
         luaL_error(L, "types.singleton: can't create singleton from `%s` type", lua_typename(L, 1));
 }

--- a/VM/include/lualib.h
+++ b/VM/include/lualib.h
@@ -59,7 +59,7 @@ LUALIB_API lua_State* luaL_newstate(void);
 
 LUALIB_API const char* luaL_findtable(lua_State* L, int idx, const char* fname, int szhint);
 
-LUALIB_API const char* luaL_typename(lua_State* L, int idx);
+LUALIB_API const char* luaL_typeof(lua_State* L, int idx);
 
 LUALIB_API void luaL_traceback(lua_State* L, lua_State* L1, const char* msg, int level);
 

--- a/VM/src/laux.cpp
+++ b/VM/src/laux.cpp
@@ -382,7 +382,7 @@ const char* luaL_findtable(lua_State* L, int idx, const char* fname, int szhint)
     return NULL;
 }
 
-const char* luaL_typename(lua_State* L, int idx)
+const char* luaL_typeof(lua_State* L, int idx)
 {
     const TValue* obj = luaA_toobject(L, idx);
     return obj ? luaT_objtypename(L, obj) : "no value";
@@ -682,7 +682,7 @@ const char* luaL_tolstring(lua_State* L, int idx, size_t* len)
     {
         const void* ptr = lua_topointer(L, idx);
         unsigned long long enc = lua_encodepointer(L, uintptr_t(ptr));
-        lua_pushfstring(L, "%s: 0x%016llx", luaL_typename(L, idx), enc);
+        lua_pushfstring(L, "%s: 0x%016llx", luaL_typeof(L, idx), enc);
         break;
     }
     }

--- a/VM/src/lbaselib.cpp
+++ b/VM/src/lbaselib.cpp
@@ -205,7 +205,7 @@ static int luaB_typeof(lua_State* L)
 {
     luaL_checkany(L, 1);
     // resulting name returns __type if specified unless the input is a newproxy-created userdata
-    lua_pushstring(L, luaL_typename(L, 1));
+    lua_pushstring(L, luaL_typeof(L, 1));
     return 1;
 }
 

--- a/VM/src/lstrlib.cpp
+++ b/VM/src/lstrlib.cpp
@@ -824,7 +824,7 @@ static void add_value(MatchState* ms, luaL_Strbuf* b, const char* s, const char*
         lua_pushlstring(L, s, e - s); // keep original text
     }
     else if (!lua_isstring(L, -1))
-        luaL_error(L, "invalid replacement value (a %s)", luaL_typename(L, -1));
+        luaL_error(L, "invalid replacement value (a %s)", luaL_typeof(L, -1));
     luaL_addvalue(b); // add result to accumulator
 }
 

--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -313,7 +313,7 @@ static void addfield(lua_State* L, luaL_Strbuf* b, int i, LuaTable* t)
     {
         int tt = lua_rawgeti(L, 1, i);
         if (tt != LUA_TSTRING && tt != LUA_TNUMBER)
-            luaL_error(L, "invalid value (%s) at index %d in table for 'concat'", luaL_typename(L, -1), i);
+            luaL_error(L, "invalid value (%s) at index %d in table for 'concat'", luaL_typeof(L, -1), i);
         luaL_addvalue(b);
     }
 }

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2904,17 +2904,17 @@ TEST_CASE("ApiType")
     lua_State* L = globalState.get();
 
     lua_pushnumber(L, 2);
-    CHECK(strcmp(luaL_typename(L, -1), "number") == 0);
-    CHECK(strcmp(luaL_typename(L, 1), "number") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "number") == 0);
+    CHECK(strcmp(luaL_typeof(L, 1), "number") == 0);
     CHECK(lua_type(L, -1) == LUA_TNUMBER);
     CHECK(lua_type(L, 1) == LUA_TNUMBER);
 
-    CHECK(strcmp(luaL_typename(L, 2), "no value") == 0);
+    CHECK(strcmp(luaL_typeof(L, 2), "no value") == 0);
     CHECK(lua_type(L, 2) == LUA_TNONE);
     CHECK(strcmp(lua_typename(L, lua_type(L, 2)), "no value") == 0);
 
     lua_newuserdata(L, 0);
-    CHECK(strcmp(luaL_typename(L, -1), "userdata") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "userdata") == 0);
     CHECK(lua_type(L, -1) == LUA_TUSERDATA);
 
     lua_newtable(L);
@@ -2922,7 +2922,7 @@ TEST_CASE("ApiType")
     lua_setfield(L, -2, "__type");
     lua_setmetatable(L, -2);
 
-    CHECK(strcmp(luaL_typename(L, -1), "hello") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "hello") == 0);
     CHECK(lua_type(L, -1) == LUA_TUSERDATA);
 }
 
@@ -2940,7 +2940,7 @@ TEST_CASE("ApiBuffer")
 
     CHECK(strcmp(lua_typename(L, LUA_TBUFFER), "buffer") == 0);
 
-    CHECK(strcmp(luaL_typename(L, -1), "buffer") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "buffer") == 0);
 
     void* p1 = lua_tobuffer(L, -1, nullptr);
 
@@ -3945,7 +3945,7 @@ TEST_CASE("LightuserdataApi")
     lua_setlightuserdataname(L, 1, "id");
     CHECK(!lua_getlightuserdataname(L, 0));
     CHECK(strcmp(lua_getlightuserdataname(L, 1), "id") == 0);
-    CHECK(strcmp(luaL_typename(L, -1), "id") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "id") == 0);
     lua_pop(L, 1);
 
     lua_pushlightuserdatatagged(L, value, 0);
@@ -3979,14 +3979,14 @@ TEST_CASE("LightuserdataApi")
 
     // Still possible to rename the global lightuserdata name using a metatable
     lua_pushlightuserdata(L, value);
-    CHECK(strcmp(luaL_typename(L, -1), "userdata") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "userdata") == 0);
 
     lua_createtable(L, 0, 1);
     lua_pushstring(L, "luserdata");
     lua_setfield(L, -2, "__type");
     lua_setmetatable(L, -2);
 
-    CHECK(strcmp(luaL_typename(L, -1), "luserdata") == 0);
+    CHECK(strcmp(luaL_typeof(L, -1), "luserdata") == 0);
     lua_pop(L, 1);
 
     globalState.reset();


### PR DESCRIPTION
* Familiarity with the `typeof` standard library member, relating what it does
* Better implies that it operates on a value instead of a type ID
* Less confusion with the difference between it and `lua_typename`
* Far less easy to make a typo between it and that (a mistake that was already made at least once in Luau itself)