### PR TITLE
Fix `luaL_typename` typo in UDTF error reporting

### DIFF
--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -33,6 +33,7 @@ LUAU_FASTFLAGVARIABLE(LuauUdtfErrorHandling)
 LUAU_FASTFLAGVARIABLE(LuauUdtfCreateSingletonFixErrorMessage)
 LUAU_FASTFLAGVARIABLE(LuauUdtfTypeUseTaggedMetatable)
 LUAU_FASTFLAGVARIABLE(LuauUdtfTypeToStringMetamethod)
+LUAU_FASTFLAGVARIABLE(LuauUdtfFixTypeNameTypo)
 
 namespace Luau
 {
@@ -312,9 +313,10 @@ std::optional<TypeFunctionError> checkResultForError(lua_State* L, const char* t
                 Location{}, RuntimeError{format("'%s' type function errored at runtime: %s", typeFunctionName, lua_tostring(L, -1))}
             };
 
+        const char* tname = FFlag::LuauUdtfFixTypeNameTypo ? luaL_typename(L, -1) : lua_typename(L, -1);
         return TypeFunctionError{
             Location{},
-            RuntimeError{format("'%s' type function errored at runtime: raised an error of type %s", typeFunctionName, lua_typename(L, -1))}
+            RuntimeError{format("'%s' type function errored at runtime: raised an error of type %s", typeFunctionName, tname)}
         };
     }
 }

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -23,6 +23,7 @@ LUAU_FASTFLAG(LuauCloneTypeFunctionFromForeignArena)
 LUAU_FASTFLAG(LuauUdtfCreateSingletonFixErrorMessage)
 LUAU_FASTFLAG(LuauUdtfTypeToStringMetamethod)
 LUAU_FASTFLAG(LuauNewTypePathErrorMessages)
+LUAU_FASTFLAG(LuauUdtfFixTypeNameTypo)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");
 
@@ -3626,6 +3627,24 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cross_type_function_type_check")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(toString(result.errors[0]).find("Expected this to be 'number', but got") == 0);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "non_string_error_value")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    ScopedFastFlag structuredErrors(FFlag::LuauTypeFunctionStructuredErrors, true);
+    ScopedFastFlag fixTypeNameTypo{FFlag::LuauUdtfFixTypeNameTypo, true};
+
+    CheckResult result = check(R"(
+        type function foo()
+            error({})
+        end
+
+        local x: foo<> = 5
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(2, result);
+    CHECK_EQ(toString(result.errors[0]), "'foo' type function errored at runtime: raised an error of type table");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
```luau
type function foo()
    error({})
end

local x: foo<> = 5 --> "'foo' type function errored at runtime: raised an error of type no value"
```

The fiix corrects it to "raised an error of type table".

Adds flag `LuauUdtfFixTypeNameTypo`. Adds 1 test.