### PR TITLE
Reject unknown options in luau-analyze

### DIFF
--- a/CLI/src/Analyze.cpp
+++ b/CLI/src/Analyze.cpp
@@ -433,6 +433,14 @@ int main(int argc, char** argv)
             basePath = std::string{argv[i] + 10};
         else if (strcmp(argv[i], "--solver=old") == 0)
             solverMode = Luau::SolverMode::Old;
+        else if (strcmp(argv[i], "--solver=new") == 0)
+            solverMode = Luau::SolverMode::New;
+        else
+        {
+            fprintf(stderr, "Error: Unrecognized option '%s'.\n\n", argv[i]);
+            displayHelp(argv[0]);
+            return 1;
+        }
     }
 
 #if !defined(LUAU_ENABLE_TIME_TRACE)


### PR DESCRIPTION
## Problem

`luau-analyze` silently ignores unrecognized command line options and can still exit successfully.

For example a typo such as:

```text
luau-analyze --mode=Strict file.luau
```

is ignored instead of reported causing analysis to run with different settings than requested. This can allow incorrectly configured CI commands to appear successful.

## Change

Reject unrecognized options with an error message display the command help and return a nonzero exit code matching the behaviour of the other supported Luau CLI tools.

This also explicitly recognizes the documented `--solver=new` option. It previously behaved successfully only because it was silently ignored and the new solver is already the default.

## Testing

Verified executable behaviour for:

- Unknown options in different argument positions
- Unknown options following valid options
- Valid source file analysis
- Valid `--annotate`, `--mode` and solver options
- Existing type error reporting
- Help output

The complete unit and conformance suites pass under the default all flags and old solver configurations.

`luau-analyze` argument parsing is not exposed through the existing `Luau.CLI.Test` target so the option behaviour was verified using an executable level command matrix.