### PR TITLE
Fix optional tagged userdata types not being remapped at load time

### DIFF
--- a/VM/src/lvmload.cpp
+++ b/VM/src/lvmload.cpp
@@ -19,6 +19,7 @@
 
 LUAU_FASTFLAG(LuauCallFeedback)
 LUAU_FASTFLAGVARIABLE(LuauCostModel)
+LUAU_FASTFLAGVARIABLE(LuauLoadRemapOptionalUserdata)
 
 template<typename T>
 struct TempBuffer
@@ -217,6 +218,18 @@ static void resolveImportSafe(lua_State* L, LuaTable* env, TValue* k, uint32_t i
     }
 }
 
+// The optional bit sits above the index, so it has to come off before the range check
+static uint8_t remapUserdataType(uint8_t type, uint8_t* userdataRemapping, uint32_t count)
+{
+    uint8_t optional = FFlag::LuauLoadRemapOptionalUserdata ? uint8_t(type & LBC_TYPE_OPTIONAL_BIT) : uint8_t(0);
+    uint32_t index = uint32_t(uint8_t(type & ~optional) - LBC_TYPE_TAGGED_USERDATA_BASE);
+
+    if (index < count)
+        return userdataRemapping[index] | optional;
+
+    return type;
+}
+
 static void remapUserdataTypes(char* data, size_t size, uint8_t* userdataRemapping, uint32_t count)
 {
     size_t offset = 0;
@@ -231,12 +244,7 @@ static void remapUserdataTypes(char* data, size_t size, uint8_t* userdataRemappi
 
         // Skip two bytes of function type introduction
         for (uint32_t i = 2; i < typeSize; i++)
-        {
-            uint32_t index = uint32_t(types[i] - LBC_TYPE_TAGGED_USERDATA_BASE);
-
-            if (index < count)
-                types[i] = userdataRemapping[index];
-        }
+            types[i] = remapUserdataType(types[i], userdataRemapping, count);
 
         offset += typeSize;
     }
@@ -246,12 +254,7 @@ static void remapUserdataTypes(char* data, size_t size, uint8_t* userdataRemappi
         uint8_t* types = (uint8_t*)data + offset;
 
         for (uint32_t i = 0; i < upvalCount; i++)
-        {
-            uint32_t index = uint32_t(types[i] - LBC_TYPE_TAGGED_USERDATA_BASE);
-
-            if (index < count)
-                types[i] = userdataRemapping[index];
-        }
+            types[i] = remapUserdataType(types[i], userdataRemapping, count);
 
         offset += upvalCount;
     }
@@ -260,10 +263,7 @@ static void remapUserdataTypes(char* data, size_t size, uint8_t* userdataRemappi
     {
         for (uint32_t i = 0; i < localCount; i++)
         {
-            uint32_t index = uint32_t(data[offset] - LBC_TYPE_TAGGED_USERDATA_BASE);
-
-            if (index < count)
-                data[offset] = userdataRemapping[index];
+            data[offset] = char(remapUserdataType(uint8_t(data[offset]), userdataRemapping, count));
 
             offset += 2;
             readVarInt(data, size, offset);

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -8653,6 +8653,10 @@ bb_bytecode_2:
 // as 'vec2' if the load-time remapping ran for the optional form as well.
 TEST_CASE_FIXTURE(LoweringFixture, "OptionalUserdataTypeRemapping")
 {
+    // This test requires runtime component to be present
+    if (!Luau::CodeGen::isSupported())
+        return;
+
     ScopedFastFlag remapOptional{FFlag::LuauLoadRemapOptionalUserdata, true};
 
     // Argument types

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAG(LuauCodegenConstVectorBufferRead)
 LUAU_FASTFLAG(LuauCodegenStoreTagCheck)
 LUAU_FASTFLAG(LuauCodegenPropagateFallbackTags)
 LUAU_FASTFLAG(LuauCodegenIntegerCompare)
+LUAU_FASTFLAG(LuauLoadRemapOptionalUserdata)
 
 #define ensureVectorSize3() \
     if constexpr (LUA_VECTOR_SIZE != 3) \
@@ -8644,6 +8645,86 @@ bb_bytecode_2:
   STORE_TAG R3, tnumber
   INTERRUPT 20u
   RETURN R3, 1i
+)"
+    );
+}
+
+// The compile-time and run-time userdata type lists are in different orders, so 'vec2?' only reports
+// as 'vec2' if the load-time remapping ran for the optional form as well.
+TEST_CASE_FIXTURE(LoweringFixture, "OptionalUserdataTypeRemapping")
+{
+    ScopedFastFlag remapOptional{FFlag::LuauLoadRemapOptionalUserdata, true};
+
+    // Argument types
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo(b: vec2?)
+    return b
+end
+)",
+                   /* includeIrTypes */ true
+               ),
+        R"(
+; function foo($arg0) line 2
+; R0: vec2? [argument]
+bb_0:
+  %0 = LOAD_TAG R0
+  JUMP_EQ_TAG %0, tnil, bb_2, bb_3
+bb_3:
+  CHECK_TAG %0, tuserdata, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  INTERRUPT 0u
+  RETURN R0, 1i
+)"
+    );
+
+    // Upvalue types
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local up: vec2? = nil
+local function foo()
+    return up
+end
+return foo
+)",
+                   /* includeIrTypes */ true,
+                   /* debugLevel */ 2
+               ),
+        R"(
+; function foo() line 3
+; U0: vec2? ['up']
+bb_bytecode_0:
+  STORE_TAG R0, tnil
+  INTERRUPT 1u
+  RETURN R0, 1i
+)"
+    );
+
+    // Local types
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo()
+    local v: vec2? = nil
+    return v
+end
+return foo
+)",
+                   /* includeIrTypes */ true,
+                   /* debugLevel */ 2
+               ),
+        R"(
+; function foo() line 2
+; R0: vec2? from 0 to 2 [local 'v']
+bb_bytecode_0:
+  STORE_TAG R0, tnil
+  INTERRUPT 1u
+  RETURN R0, 1i
 )"
     );
 }


### PR DESCRIPTION
`remapUserdataTypes` rewrites userdata type indices in the bytecode to host indices by name. It computes `types[i] - LBC_TYPE_TAGGED_USERDATA_BASE` and bounds checks the result, which also decides whether the byte is a tagged userdata type at all. `LBC_TYPE_OPTIONAL_BIT` sits above the index, so an optional tagged type falls outside that range and keeps whatever slot the blob assigned it.

The result is a valid type naming a different class. For example in Roblox's case, this could mean that a `BasePart?` parameter can reach codegen's host hooks as `CFrame?`, or some other userdata type depending on in what order they were defined. The host hook will then emit a tag check which is probably always going to fail, causing codegen to exit and run on the interpreter.

This change masks the optional bit off before the range check and reapplies it after, for all three type arrays the loader rewrites. It's flagged behind `LuauLoadRemapOptionalUserdata`.

## Testing

`OptionalUserdataTypeRemapping` covers argument, upvalue and local types. The fixture registers its compile time and run time userdata lists in different orders, so `vec2?` only reports as `vec2` if remapping ran, and all three assertions fail without the fix.
