### PR TITLE
Resolve table field types through chained type aliases

### DIFF
--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -5,6 +5,7 @@
 
 LUAU_FASTFLAG(LuauIntegerFastcalls)
 LUAU_FASTFLAGVARIABLE(LuauCompileRecursiveAliases)
+LUAU_FASTFLAGVARIABLE(LuauCompileResolveAliasChains)
 
 namespace Luau
 {
@@ -306,6 +307,32 @@ struct TypeMapVisitor : AstVisitor
         return ty;
     }
 
+    // An alias can name another alias, so a single step can land on a reference rather than the
+    // table it stands for and leave the field lookup with nothing to search
+    const AstType* resolveAliases(const AstType* ty)
+    {
+        if (!FFlag::LuauCompileResolveAliasChains)
+            return resolveAliases_DEPRECATED(ty);
+
+        DenseHashSet<AstName> seenAliases;
+
+        while (const AstTypeReference* ref = ty->as<AstTypeReference>())
+        {
+            if (ref->prefix || seenAliases.contains(ref->name))
+                break;
+
+            AstStatTypeAlias* const* alias = typeAliases.find(ref->name);
+
+            if (!alias || !*alias)
+                break;
+
+            seenAliases.insert(ref->name);
+            ty = (*alias)->type;
+        }
+
+        return ty;
+    }
+
     const AstTableIndexer* tryGetTableIndexer(AstExpr* expr)
     {
         if (const AstType** typePtr = resolvedExprs.find(expr))
@@ -319,7 +346,7 @@ struct TypeMapVisitor : AstVisitor
 
     LuauBytecodeType recordResolvedType(AstExpr* expr, const AstType* ty)
     {
-        ty = resolveAliases_DEPRECATED(ty);
+        ty = resolveAliases(ty);
 
         resolvedExprs[expr] = ty;
 
@@ -331,7 +358,7 @@ struct TypeMapVisitor : AstVisitor
 
     LuauBytecodeType recordResolvedType(AstLocal* local, const AstType* ty)
     {
-        ty = resolveAliases_DEPRECATED(ty);
+        ty = resolveAliases(ty);
 
         resolvedLocals[local] = ty;
 

--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -326,6 +326,11 @@ struct TypeMapVisitor : AstVisitor
             if (!alias || !*alias)
                 break;
 
+            // TODO: type arguments are not substituted, so stepping into a generic alias body
+            // would resolve its parameters against nothing
+            if ((*alias)->generics.size != 0 || (*alias)->genericPacks.size != 0)
+                break;
+
             seenAliases.insert(ref->name);
             ty = (*alias)->type;
         }

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -31,6 +31,7 @@ LUAU_FASTFLAG(LuauCompileContinueEagerClose)
 LUAU_FASTFLAG(LuauIntegerBufferFastcalls)
 LUAU_FASTFLAG(LuauCompileEmitVectorDouble)
 LUAU_FASTFLAG(LuauCompileMoveElision)
+LUAU_FASTFLAG(LuauCompileResolveAliasChains)
 LUAU_FASTFLAG(LuauCompileConcatTargetTop)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
@@ -4148,6 +4149,63 @@ SETUPVAL R4 0
 GETIMPORT R4 3 [a]
 RETURN R4 1
 )");
+}
+
+TEST_CASE("TableFieldTypesThroughAliasChain")
+{
+    ScopedFastFlag chains{FFlag::LuauCompileResolveAliasChains, true};
+
+    auto compileTypes = [](const char* source)
+    {
+        Luau::BytecodeBuilder bcb;
+        bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code | Luau::BytecodeBuilder::Dump_Types);
+        bcb.setDumpSource(source);
+
+        Luau::CompileOptions options;
+        options.vectorType = "vector";
+        options.typeInfoLevel = 1;
+
+        Luau::compileOrThrow(bcb, source, options);
+
+        return "\n" + bcb.dumpFunction(0);
+    };
+
+    // Chained alias
+    CHECK_EQ(
+        compileTypes(R"(
+type Vertex = {pos: vector, normal: vector}
+type Alias = Vertex
+
+function foo(v: Alias)
+    local p = v.pos
+    return p
+end
+)"),
+        R"(
+R0: table [argument]
+R1: vector from 0 to 3
+GETTABLEKS R1 R0 K0 ['pos']
+RETURN R1 1
+)"
+    );
+
+    // Mutually recursive aliases
+    CHECK_EQ(
+        compileTypes(R"(
+type A = B
+type B = A
+
+function foo(v: A)
+    local p = v.pos
+    return p
+end
+)"),
+        R"(
+R1: any from 0 to 3
+GETTABLEKS R1 R0 K0 ['pos']
+RETURN R1 1
+)"
+    );
 }
 
 TEST_CASE("CostModelRemarks")

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -2559,10 +2559,8 @@ until (function() return rr end)() < 0.5
 
     // unless that upvalue is from an outer scope
     CHECK_EQ(
-        "\n" + compileFunction0(
-                   "local stop = false stop = true function test() repeat local r = math.random() if r > 0.5 then "
-                   "continue end r = r + 0.3 until stop or r < 0.5 end"
-               ),
+        "\n" + compileFunction0("local stop = false stop = true function test() repeat local r = math.random() if r > 0.5 then "
+                                "continue end r = r + 0.3 until stop or r < 0.5 end"),
         R"(
 L0: GETIMPORT R0 2 [math.random]
 CALLFB R0 0 1 [0]
@@ -4186,6 +4184,27 @@ R0: table [argument]
 R1: vector from 0 to 3
 GETTABLEKS R1 R0 K0 ['pos']
 RETURN R1 1
+)"
+    );
+
+    // Generic alias
+    CHECK_EQ(
+        compileTypes(R"(
+type Map<K, V> = { [K]: V }
+type Rec = { n: number }
+type ComponentIndex = Map<string, Rec>
+
+function foo(m: ComponentIndex, k: string)
+    local r = m[k]
+    return r
+end
+)"),
+        R"(
+R0: table [argument]
+R1: string [argument]
+R2: any from 0 to 2
+GETTABLE R2 R0 R1
+RETURN R2 1
 )"
     );
 


### PR DESCRIPTION
`recordResolvedType` resolves a single alias step, so an alias naming another alias hands the field lookup an `AstTypeReference` instead of the table it stands for. The lookup finds nothing and every field read through that alias stays untyped.

`getType` in the same file already walks the chain with cycle protection, so the two resolvers disagree about the same alias. This makes the second one match, so `type Alias = Vertex` behaves like `type Alias = {pos: vector}`. Only the bytecode compiler's type map is affected, which means the cost is lost specialization in native code rather than anything type checking sees. Flagged behind `LuauCompileResolveAliasChains`.

An example of where it applies:
```luau
type Vertex = {pos: vector}
type Alias = Vertex

return function(v: Alias)
    return v.pos.y
end
```
Without this change, v.pos is of type any, and y is a hash lookup. The scope is alias chains within a single script, since the compiler cannot see types that arrive through `require`. If the compiler is one day able to see those types, this would apply to the many scripts that get their type from a required module.

## Testing

`TableFieldTypesThroughAliasChain` covers a chained alias and a mutually recursive pair. Without the fix the chained case types the field read as `any` instead of `vector`.