### PR TITLE
Fix os.time return type when called with a date table

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -169,7 +169,7 @@ type DateTypeResult = {
 }
 
 declare os: {
-    time: (time: DateTypeArg?) -> number,
+    time: (() -> number) & ((time: DateTypeArg) -> number?),
     date: ((formatString: "*t" | "!*t", time: number?) -> DateTypeResult) & ((formatString: string?, time: number?) -> string),
     difftime: (t2: DateTypeResult | number, t1: DateTypeResult | number) -> number,
     clock: () -> number,

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -503,8 +503,19 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "os_time_takes_optional_date_table")
 
     LUAU_REQUIRE_NO_ERRORS(result);
     CHECK("number" == toString(requireType("n1")));
-    CHECK("number" == toString(requireType("n2")));
-    CHECK("number" == toString(requireType("n3")));
+    CHECK("number?" == toString(requireType("n2")));
+    CHECK("number?" == toString(requireType("n3")));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "os_time_with_date_table_may_return_nil")
+{
+    // os.time returns nil when the date table is out of range, so the result
+    // must not be used as a number without a check.
+    CheckResult result = check(R"(
+        local n: number = os.time({ year = 0, month = 0, day = 0 })
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "thread_is_a_type")


### PR DESCRIPTION
Fixes #2668

`os.time` returns nil at runtime when the date table is out of range - the conformance suite itself relies on this (`assert(os.time({ year = 1969, ... }) == nil)` in `tests/conformance/datetime.luau`) - but the builtin annotation claimed a plain `number` for every call. Code doing arithmetic on the result passed the type checker and then failed with `attempt to perform arithmetic (add) on nil and number`.

The annotation is now two overloads:

```luau
time: (() -> number) & ((time: DateTypeArg) -> number?),
```

- the argument-less call still returns `number`
- a call with a date table returns `number?`

One note from testing: I first tried making the second overload's parameter optional (`DateTypeArg?`). That made it also match zero-argument calls, and the old solver rejected every plain `os.time()` with an ambiguous-call error, so the parameter stays required.

Updated `os_time_takes_optional_date_table` expectations and added a regression test asserting that assigning the table-call result to `number` now errors. Full suite passes locally (5613 test cases).