### PR TITLE
Named Cycle Type Stringification

### DIFF
--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -20,6 +20,7 @@
 
 LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAGVARIABLE(LuauBetterInferredGenericNames)
+LUAU_FASTFLAGVARIABLE(LuauNamedCycleTypes)
 
 /*
  * Enables increasing levels of verbosity for Luau type names when stringifying.
@@ -1443,6 +1444,41 @@ void TypeStringifier::stringify(TypePackId tpid, const std::vector<std::optional
     tps.stringify(tpid);
 }
 
+static void assignCycleNames2(
+    const std::set<TypeId>& cycles,
+    const std::set<TypePackId>& cycleTPs,
+    DenseHashMap2<TypeId, std::string>& cycleNames,
+    DenseHashMap2<TypePackId, std::string>& cycleTpNames,
+    bool ignoreSyntheticName
+)
+{
+    int nextIndex = 1;
+
+    for (TypeId cycleTy : cycles)
+    {
+        std::string name;
+
+        if (auto ttv = get<TableType>(follow(cycleTy)); ttv && (ttv->name || (ttv->syntheticName && !ignoreSyntheticName)))
+        {
+            cycleNames[cycleTy] = ttv->name ? *ttv->name : *ttv->syntheticName;
+
+            continue;
+        }
+
+        name = "t" + std::to_string(nextIndex);
+        ++nextIndex;
+
+        cycleNames[cycleTy] = std::move(name);
+    }
+
+    for (TypePackId tp : cycleTPs)
+    {
+        std::string name = "tp" + std::to_string(nextIndex);
+        ++nextIndex;
+        cycleTpNames[tp] = std::move(name);
+    }
+}
+
 static void assignCycleNames(
     const std::set<TypeId>& cycles,
     const std::set<TypePackId>& cycleTPs,
@@ -1547,7 +1583,10 @@ ToStringResult toStringDetailed(TypeId ty, ToStringOptions& opts)
 
     findCyclicTypes(cycles, cycleTPs, ty, opts.exhaustive);
 
-    assignCycleNames(cycles, cycleTPs, state.cycleNames, state.cycleTpNames, opts.exhaustive);
+    if (FFlag::LuauNamedCycleTypes)
+        assignCycleNames2(cycles, cycleTPs, state.cycleNames, state.cycleTpNames, opts.ignoreSyntheticName);
+    else
+        assignCycleNames(cycles, cycleTPs, state.cycleNames, state.cycleTpNames, opts.exhaustive);
 
     TypeStringifier tvs{state};
 
@@ -1679,7 +1718,10 @@ ToStringResult toStringDetailed(TypePackId tp, ToStringOptions& opts)
 
     findCyclicTypes(cycles, cycleTPs, tp, opts.exhaustive);
 
-    assignCycleNames(cycles, cycleTPs, state.cycleNames, state.cycleTpNames, opts.exhaustive);
+    if (FFlag::LuauNamedCycleTypes)
+        assignCycleNames2(cycles, cycleTPs, state.cycleNames, state.cycleTpNames, opts.ignoreSyntheticName);
+    else
+        assignCycleNames(cycles, cycleTPs, state.cycleNames, state.cycleTpNames, opts.exhaustive);
 
     TypeStringifier tvs{state};
 

--- a/tests/Normalize.test.cpp
+++ b/tests/Normalize.test.cpp
@@ -17,6 +17,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauAlwaysIntersectTablesWithTables)
 LUAU_FASTFLAG(LuauIncludeExternTypeExtensionsWithTopExternType)
+LUAU_FASTFLAG(LuauNamedCycleTypes)
 
 using namespace Luau;
 
@@ -787,6 +788,8 @@ TEST_CASE_FIXTURE(Fixture, "higher_order_function_with_annotation")
 
 TEST_CASE_FIXTURE(Fixture, "cyclic_table_normalizes_sensibly")
 {
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+
     CheckResult result = check(R"(
         local Cyclic = {}
         function Cyclic.get()
@@ -798,9 +801,9 @@ TEST_CASE_FIXTURE(Fixture, "cyclic_table_normalizes_sensibly")
 
     TypeId ty = requireType("Cyclic");
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK_EQ("t1 where t1 = { get: () -> t1 }", toString(ty, {true}));
+        CHECK_EQ("Cyclic where Cyclic = { get: () -> Cyclic }", toString(ty, {true}));
     else
-        CHECK_EQ("t1 where t1 = {| get: () -> t1 |}", toString(ty, {true}));
+        CHECK_EQ("Cyclic where Cyclic = {| get: () -> Cyclic |}", toString(ty, {true}));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "skip_force_normal_on_external_types")

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -177,6 +177,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "named_metatable_toStringNamedFunction")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "exhaustive_toString_of_cyclic_table")
 {
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+
     CheckResult result = check(R"(
         --!strict
         local Vec3 = {}
@@ -204,17 +206,17 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "exhaustive_toString_of_cyclic_table")
     if (!FFlag::DebugLuauForceOldSolver)
     {
         CHECK(
-            "t2 where "
-            "t1 = { __index: t1, __mul: ((t2, number) -> t2) & ((t2, t2) -> t2), new: () -> t2 } ; "
-            "t2 = { @metatable t1, { x: number, y: number, z: number } }" == a
+            "t1 where "
+            "Vec3 = { __index: Vec3, __mul: ((t1, number) -> t1) & ((t1, t1) -> t1), new: () -> t1 } ; "
+            "t1 = { @metatable Vec3, { x: number, y: number, z: number } }" == a
         );
     }
     else
     {
         CHECK_EQ(
-            "t2 where "
-            "t1 = {| __index: t1, __mul: ((t2, number) -> t2) & ((t2, t2) -> t2), new: () -> t2 |} ; "
-            "t2 = { @metatable t1, { x: number, y: number, z: number } }",
+            "t1 where "
+            "Vec3 = { | __index: Vec3, __mul: ((t1, number) -> t1) & ((t1, t1) -> t1), new: () -> t1 | } ; "
+            "t1 = { @metatable Vec3, { x: number, y: number, z: number } }",
             a
         );
     }

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -14,6 +14,7 @@ using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauNewTypePathErrorMessages)
+LUAU_FASTFLAG(LuauNamedCycleTypes)
 
 TEST_SUITE_BEGIN("ToString");
 
@@ -1066,6 +1067,34 @@ TEST_CASE_FIXTURE(Fixture, "record_type_compositions_generic")
     CHECK_EQ(startPosObject, 4);
     CHECK_EQ(endPosObject, 10);
     CHECK_EQ(recordedTyObject, requireTypeAlias("Object"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "cycle_type_naming")
+{
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+
+    CheckResult result = check(R"(
+		type Foo = {
+			bar: Foo
+		}
+		type Meow = {
+			mrrp: Foo
+		}
+		type Nyan<T> = {
+			Meow | Nyan<T>
+		}
+		type Kya = Nyan<Foo>
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+
+    ToStringOptions opts;
+    opts.exhaustive = true;
+    opts.ignoreSyntheticName = false;
+
+    CHECK("Foo where Foo = { bar: Foo }" == toString(requireTypeAlias("Foo"), opts));
+    CHECK("{ mrrp: Foo } where Foo = { bar: Foo }" == toString(requireTypeAlias("Meow"), opts));
+    CHECK("Kya where Foo = { bar: Foo } ; Kya = {Kya | { mrrp: Foo }}" == toString(requireTypeAlias("Kya"), opts));
 }
 
 TEST_SUITE_END();

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -1073,7 +1073,10 @@ TEST_CASE_FIXTURE(Fixture, "record_type_compositions_generic")
 
 TEST_CASE_FIXTURE(Fixture, "cycle_type_naming")
 {
-    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauNamedCycleTypes, true},
+        {FFlag::DebugLuauForceOldSolver, false},
+    };
 
     CheckResult result = check(R"(
     type Foo = {
@@ -1100,7 +1103,10 @@ TEST_CASE_FIXTURE(Fixture, "cycle_type_naming")
 
 TEST_CASE_FIXTURE(Fixture, "cycle_type_syntheticname")
 {
-    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauNamedCycleTypes, true},
+        {FFlag::DebugLuauForceOldSolver, false},
+    };
 
     CheckResult result = check(R"(
         local meow = {}
@@ -1122,7 +1128,10 @@ TEST_CASE_FIXTURE(Fixture, "cycle_type_syntheticname")
 
 TEST_CASE_FIXTURE(Fixture, "cycle_type_ignoresyntheticname")
 {
-    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauNamedCycleTypes, true},
+        {FFlag::DebugLuauForceOldSolver, false},
+    };
 
     CheckResult result = check(R"(
         local meow = {}

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -1074,16 +1074,39 @@ TEST_CASE_FIXTURE(Fixture, "cycle_type_naming")
     ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
 
     CheckResult result = check(R"(
-		type Foo = {
-			bar: Foo
-		}
-		type Meow = {
-			mrrp: Foo
-		}
-		type Nyan<T> = {
-			Meow | Nyan<T>
-		}
-		type Kya = Nyan<Foo>
+    type Foo = {
+        bar: Foo
+    }
+    type Meow = {
+        mrrp: Foo
+    }
+    type Nyan<T> = {
+        Meow | Nyan<T>
+    }
+    type Kya = Nyan<Foo>
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+
+    ToStringOptions opts;
+    opts.exhaustive = true;
+
+    CHECK("Foo where Foo = { bar: Foo }" == toString(requireTypeAlias("Foo"), opts));
+    CHECK("{ mrrp: Foo } where Foo = { bar: Foo }" == toString(requireTypeAlias("Meow"), opts));
+    CHECK("Kya where Foo = { bar: Foo } ; Kya = {Kya | { mrrp: Foo }}" == toString(requireTypeAlias("Kya"), opts));
+}
+
+TEST_CASE_FIXTURE(Fixture, "cycle_type_syntheticname")
+{
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+
+    CheckResult result = check(R"(
+        local meow = {}
+        meow.mrrp = meow
+        local function foo(bar)
+       	    bar.baz(meow)
+        end
+        type A = typeof(foo)
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
@@ -1092,9 +1115,29 @@ TEST_CASE_FIXTURE(Fixture, "cycle_type_naming")
     opts.exhaustive = true;
     opts.ignoreSyntheticName = false;
 
-    CHECK("Foo where Foo = { bar: Foo }" == toString(requireTypeAlias("Foo"), opts));
-    CHECK("{ mrrp: Foo } where Foo = { bar: Foo }" == toString(requireTypeAlias("Meow"), opts));
-    CHECK("Kya where Foo = { bar: Foo } ; Kya = {Kya | { mrrp: Foo }}" == toString(requireTypeAlias("Kya"), opts));
+    CHECK("({ read baz: (meow) -> (...unknown) }) -> () where meow = { mrrp: meow }" == toString(requireTypeAlias("A"), opts));
+}
+
+TEST_CASE_FIXTURE(Fixture, "cycle_type_ignoresyntheticname")
+{
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+
+    CheckResult result = check(R"(
+        local meow = {}
+        meow.mrrp = meow
+        local function foo(bar)
+       	    bar.baz(meow)
+        end
+        type A = typeof(foo)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+
+    ToStringOptions opts;
+    opts.exhaustive = true;
+    opts.ignoreSyntheticName = true;
+
+    CHECK("({ read baz: (t1) -> (...unknown) }) -> () where t1 = { mrrp: t1 }" == toString(requireTypeAlias("A"), opts));
 }
 
 TEST_SUITE_END();

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -215,7 +215,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "exhaustive_toString_of_cyclic_table")
     {
         CHECK_EQ(
             "t1 where "
-            "Vec3 = { | __index: Vec3, __mul: ((t1, number) -> t1) & ((t1, t1) -> t1), new: () -> t1 | } ; "
+            "Vec3 = {| __index: Vec3, __mul: ((t1, number) -> t1) & ((t1, t1) -> t1), new: () -> t1 |} ; "
             "t1 = { @metatable Vec3, { x: number, y: number, z: number } }",
             a
         );

--- a/tests/TypeInfer.aliases.test.cpp
+++ b/tests/TypeInfer.aliases.test.cpp
@@ -613,7 +613,8 @@ type X = Import.X
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "type_alias_of_an_imported_recursive_generic_type")
 {
-    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+    ScopedFastFlag sffs
+        {FFlag::LuauNamedCycleTypes, true};
 
     fileResolver.source["game/A"] = R"(
         export type X<T, U> = { a: T, b: U, C: X<T, U>? }
@@ -657,7 +658,9 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "type_alias_of_an_imported_recursive_generic_
     else
     {
         CHECK_EQ(toString(*ty1, {true}), "X where X = { C: X?, a: T, b: U }");
-        CHECK_EQ(toString(*ty2, {true}), "{ C: X, a: U, b: T } where X = { C: X, a: U, b: T }?");
+        // i can only assume that 't1' displaying *specifically* on
+        // the old solver is an unrelated bug
+        CHECK_EQ(toString(*ty2, {true}), "{ C: t1, a: U, b: T } where t1 = { C: t1, a: U, b: T }?");
     }
 }
 

--- a/tests/TypeInfer.aliases.test.cpp
+++ b/tests/TypeInfer.aliases.test.cpp
@@ -613,8 +613,7 @@ type X = Import.X
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "type_alias_of_an_imported_recursive_generic_type")
 {
-    ScopedFastFlag sffs
-        {FFlag::LuauNamedCycleTypes, true};
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
 
     fileResolver.source["game/A"] = R"(
         export type X<T, U> = { a: T, b: U, C: X<T, U>? }

--- a/tests/TypeInfer.aliases.test.cpp
+++ b/tests/TypeInfer.aliases.test.cpp
@@ -14,6 +14,7 @@ LUAU_FASTFLAG(LuauDisallowRedefiningBuiltinTypes)
 LUAU_FASTFLAG(LuauInstantiationCheckArguments)
 LUAU_FASTFLAG(LuauInstantiationCheckArgumentsDedup)
 LUAU_FASTFLAG(LuauBlockingTypeAliasExpansion)
+LUAU_FASTFLAG(LuauNamedCycleTypes)
 
 TEST_SUITE_BEGIN("TypeAliases");
 
@@ -612,6 +613,7 @@ type X = Import.X
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "type_alias_of_an_imported_recursive_generic_type")
 {
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
 
     fileResolver.source["game/A"] = R"(
         export type X<T, U> = { a: T, b: U, C: X<T, U>? }
@@ -649,13 +651,13 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "type_alias_of_an_imported_recursive_generic_
 
     if (!FFlag::DebugLuauForceOldSolver)
     {
-        CHECK(toString(*ty1, {true}) == "t1 where t1 = { C: t1?, a: T, b: U }");
-        CHECK(toString(*ty2, {true}) == "t1 where t1 = { C: t1?, a: U, b: T }");
+        CHECK(toString(*ty1, {true}) == "X where X = { C: X?, a: T, b: U }");
+        CHECK(toString(*ty2, {true}) == "X where X = { C: X?, a: U, b: T }");
     }
     else
     {
-        CHECK_EQ(toString(*ty1, {true}), "t1 where t1 = { C: t1?, a: T, b: U }");
-        CHECK_EQ(toString(*ty2, {true}), "{ C: t1, a: U, b: T } where t1 = { C: t1, a: U, b: T }?");
+        CHECK_EQ(toString(*ty1, {true}), "X where X = { C: X?, a: T, b: U }");
+        CHECK_EQ(toString(*ty2, {true}), "{ C: X, a: U, b: T } where X = { C: X, a: U, b: T }?");
     }
 }
 
@@ -1391,7 +1393,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "unpack_doesnt_emplace_typeof_type")
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         local Obj = {}
-        
+
         local function g(): number
             return 42
         end

--- a/tests/TypeInfer.oop.test.cpp
+++ b/tests/TypeInfer.oop.test.cpp
@@ -17,6 +17,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(LuauSetmetatableOverrides)
+LUAU_FASTFLAG(LuauNamedCycleTypes)
 
 TEST_SUITE_BEGIN("TypeInferOOP");
 
@@ -742,7 +743,10 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_allows_upcast")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_disallows_invalid_upcast")
 {
-    ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sffs[] {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauNamedCycleTypes, true},
+    };
 
     CheckResult results = check(R"(
         local Foobar = {}
@@ -758,7 +762,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_disallows_invalid_upcast")
     auto err = get<TypeMismatch>(results.errors[0]);
     REQUIRE(err);
     CHECK_EQ("{ const: number }", toString(err->wantedType));
-    CHECK_EQ("{ @metatable t1, {  } } where t1 = { __index: t1, const: number }", toString(err->givenType, {/* exhaustive */ true}));
+    CHECK_EQ("{ @metatable Foobar, {  } } where Foobar = { __index: Foobar, const: number }", toString(err->givenType, {/* exhaustive */ true}));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_field_precedence_for_subtyping")

--- a/tests/TypeInfer.typePacks.test.cpp
+++ b/tests/TypeInfer.typePacks.test.cpp
@@ -13,6 +13,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
 LUAU_FASTFLAG(LuauNewTypePathErrorMessages)
+LUAU_FASTFLAG(LuauNamedCycleTypes)
 
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 
@@ -908,6 +909,8 @@ type C = A<string, (number), (boolean)>
 
 TEST_CASE_FIXTURE(Fixture, "type_alias_defaults_recursive_type")
 {
+    ScopedFastFlag sff{FFlag::LuauNamedCycleTypes, true};
+
     CheckResult result = check(R"(
 type F<K = string, V = (K) -> ()> = (K) -> V
 type R = { m: F<R> }
@@ -915,7 +918,7 @@ type R = { m: F<R> }
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(toString(*lookupType("R"), {true}), "t1 where t1 = { m: (t1) -> (t1) -> () }");
+    CHECK_EQ(toString(*lookupType("R"), {true}), "R where R = { m: (R) -> (R) -> () }");
 }
 
 TEST_CASE_FIXTURE(Fixture, "pack_tail_unification_check")


### PR DESCRIPTION
- changes `t1 where t1 = ...` to `Alias where Alias = ...`
- fully flagged behind `LuauNamedCycleTypes`
- authored and ran tests on NixOS 26.05 x86_64 w/ `make test`
- 100% human made

reading types like `t1` can be very unhelpful in types. Currently, exhaustive ToString doesn't really make use of TableType.name/TableType.syntheticName much at all. However, i think we should use both more in places where we otherwise assign junk numbered names. In graph / data-heavy code, you might have a *lot* of types which are recursive. Here's a sample of a stringified type from my code:

```luau
type EntRecord = {
    id: Ent,
    immortal: true?,
    increment: t4?,
    on_adds: t5?,
    on_changes: t6?,
    on_detach: t3?,
    on_removes: t2?,
    stable_frag: t1,
    stable_row: FragRow,
    var_frag: t1,
    var_row: FragRow,
} where t1 = {
	read adjacent: { [Id]: t1? },
	clean_count: FragRow | Zero,
	...
```

Although I could use an in-exhaustive ToString and enable synthetic names, that'd make the entire type display as `EntRecord`, hiding a bunch of useful information. Instead, after putting a version of my code into an exhaustive ToString with my changes, I got something like this:

```luau
type EntRecord = {
	id: Ent,
	immortal: true?,
	increment: Increment?,
	on_adds: SignalAdds?,
	on_changes: SignalChanges?,
	on_detach: SignalDetach?,
	on_removes: SignalRemoves?,
	stable_frag: Frag,
	stable_row: FragRow,
	var_frag: Frag,
	var_row: FragRow
} where Frag = {
	read adjacent: { [Id]: Frag? },
	clean_count: FragRow | Zero,
	...
```

this is still exhaustive (which is super useful!), but objectively better to read.

if `ignoreSyntheticName` is enabled in ToStringOpts, tests make sure it still shows `t1 where t1 = ...` for recursive types without a type namespace name.