### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{h,cpp}]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,10 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.{h,cpp}]
 indent_style = space
+
+[*.{h,cpp,py}]
 indent_size = 4
+
+[*.{yml}]
+indent_size = 2


### PR DESCRIPTION
many editors either support [.editorconfig](https://editorconfig.org/) outright or have plugins to add compatibility. This one is pretty simple, setting charset to UTF-8, eol to LF, as well as indent_size / indent_style to 4 / space respectively in .cpp & .h files. There's no .gitignore for this, but my impression is that it would be a lot more acceptable than editor-specific configuration (almost the entire editorconfig spec is used here, and i think what i've added is pretty un-opinionated)
