### PR TITLE
Report input files that could not be opened in luau-analyze

### DIFF
--- a/CLI/src/Analyze.cpp
+++ b/CLI/src/Analyze.cpp
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <fstream>
 
@@ -534,6 +535,17 @@ int main(int argc, char** argv)
 
     for (const Luau::ModuleName& name : checkedModules)
         failed += !reportModuleResult(frontend, name, format, annotate);
+
+    std::unordered_set<Luau::ModuleName> checkedNames(checkedModules.begin(), checkedModules.end());
+
+    for (const std::string& path : files)
+    {
+        if (checkedNames.count(path) == 0)
+        {
+            fprintf(stderr, "Error opening %s\n", path.c_str());
+            failed++;
+        }
+    }
 
     if (!configResolver.configErrors.empty())
     {


### PR DESCRIPTION
## Problem

`luau-analyze` silently ignores input files that cannot be opened and can still exit successfully.

For example:

```text
luau-analyze nosuchfile.luau
```

produces no output and returns an exit code of `0`. A missing file is also ignored when mixed with valid inputs allowing CI commands containing stale or misspelled paths to appear successful.

## Change

Report explicitly requested input files that could not be opened using the existing `Error opening <path>` message and return a nonzero exit code matching the behaviour of the other Luau CLI tools.

Requested files are checked separately because the existing `checkedModules` list also contains dependencies discovered through `require` whose reporting behaviour should remain unchanged.

## Testing

Verified executable behaviour for:

* A missing input file
* A missing file mixed with a valid file
* Valid source file analysis
* Existing type error reporting
* Empty directory analysis
* Files containing `require` dependencies
* Directory scanning

The complete unit and conformance suites pass under the default all flags and old solver configurations.

`CLI/src/Analyze.cpp` is not compiled into the existing `Luau.CLI.Test` target so the missing file behaviour was verified using an executable level command matrix.