### PR TITLE
Fix table properties being inferred as readonly with compound assignment

### DIFF
--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -53,6 +53,7 @@ LUAU_FASTFLAGVARIABLE(LuauUdtfPopulateEnv)
 LUAU_FASTFLAG(LuauIterableConstraintMutatesIterator)
 LUAU_FASTFLAG(LuauSetmetatableOverrides)
 LUAU_FASTFLAGVARIABLE(LuauThreadGeneralizeThroughConstraintGeneration)
+LUAU_FASTFLAGVARIABLE(LuauCompoundAssignRecordsPropertyWrite)
 
 namespace Luau
 {
@@ -2011,8 +2012,22 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatCompoundAss
 {
     TypeId resultTy = checkAstExprBinary(scope, assign->location, assign->op, assign->var, assign->value, std::nullopt).ty;
     module->astCompoundAssignResultTypes[assign] = resultTy;
-    // NOTE: We do not update lvalues for compound assignments. This is
-    // intentional.
+
+    // NOTE: We do not update the typestate of lvalues for compound assignments.
+    // This is intentional.
+    const bool varIsProperty = assign->var->is<AstExprIndexName>() || assign->var->is<AstExprIndexExpr>();
+
+    if (FFlag::LuauCompoundAssignRecordsPropertyWrite && varIsProperty)
+    {
+        TypeId* readTy = module->astTypes.find(assign->var);
+        TypeId savedReadTy = readTy ? *readTy : nullptr;
+
+        visitLValue(scope, assign->var, resultTy);
+
+        if (savedReadTy)
+            module->astTypes[assign->var] = savedReadTy;
+    }
+
     return ControlFlow::None;
 }
 

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -2015,9 +2015,7 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatCompoundAss
 
     // NOTE: We do not update the typestate of lvalues for compound assignments.
     // This is intentional.
-    const bool varIsProperty = assign->var->is<AstExprIndexName>() || assign->var->is<AstExprIndexExpr>();
-
-    if (FFlag::LuauCompoundAssignRecordsPropertyWrite && varIsProperty)
+    if (FFlag::LuauCompoundAssignRecordsPropertyWrite && (assign->var->is<AstExprIndexName>() || assign->var->is<AstExprIndexExpr>()))
     {
         TypeId* readTy = module->astTypes.find(assign->var);
         TypeId savedReadTy = readTy ? *readTy : nullptr;

--- a/tests/TypeInfer.operators.test.cpp
+++ b/tests/TypeInfer.operators.test.cpp
@@ -21,6 +21,7 @@ LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
 LUAU_FASTFLAG(LuauCompoundAssignSeedsAstTypes)
+LUAU_FASTFLAG(LuauCompoundAssignRecordsPropertyWrite)
 
 TEST_SUITE_BEGIN("TypeInferOperators");
 
@@ -410,6 +411,108 @@ TEST_CASE_FIXTURE(Fixture, "compound_assign_basic")
         s += 20
     )");
     CHECK_EQ(0, result.errors.size());
+    CHECK_EQ(toString(requireType("s")), "number");
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assign_infers_read_write_property")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        local function f(x)
+            x.h += 1
+            return x.h > 2
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("({ h: number }) -> boolean", toString(requireType("f")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assign_infers_same_property_as_ordinary_assign")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        local function ordinary(x)
+            x.h = x.h + 1
+            return x.h > 2
+        end
+
+        local function compound(x)
+            x.h += 1
+            return x.h > 2
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ(toString(requireType("ordinary")), toString(requireType("compound")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assign_infers_read_write_property_for_other_operators")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        local function f(x)
+            x.h *= 2
+            return x.h > 2
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("({ h: number }) -> boolean", toString(requireType("f")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assign_infers_read_write_property_through_index_expr")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        local function f(x)
+            x["h"] += 1
+            return x["h"] > 2
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("({ h: number }) -> boolean", toString(requireType("f")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assign_on_mutable_property_is_still_ok")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        type T = { h: number }
+        local function f(x: T)
+            x.h += 1
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assign_does_not_widen_local")
+{
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        local s = 10
+        s += 20
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
     CHECK_EQ(toString(requireType("s")), "number");
 }
 

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -34,6 +34,7 @@ LUAU_FASTFLAG(LuauDontBlockRefinementUnconditionally)
 LUAU_FASTFLAG(LuauIterableConstraintMutatesIterator)
 LUAU_FASTFLAG(LuauCallErrorReportingRecoversArgumentLocationsForPacks)
 LUAU_FASTFLAG(LuauRelateIndexersTypo)
+LUAU_FASTFLAG(LuauCompoundAssignRecordsPropertyWrite)
 
 
 TEST_SUITE_BEGIN("TableTests");
@@ -7111,6 +7112,59 @@ TEST_CASE_FIXTURE(Fixture, "compound_assignment_writes_lhs")
 
         local foo: T = { x = 5 }
         foo.x += 5
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    REQUIRE(get<PropertyAccessViolation>(result.errors[0]));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assignment_to_read_only_property_still_errors")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        type T = { read x: number }
+
+        local foo: T = { x = 5 }
+        foo.x += 5
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    REQUIRE(get<PropertyAccessViolation>(result.errors[0]));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assignment_to_write_only_property_still_errors")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        type T = { write x: number }
+
+        local function f(foo: T)
+            foo.x += 5
+        end
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    REQUIRE(get<PropertyAccessViolation>(result.errors[0]));
+}
+
+TEST_CASE_FIXTURE(Fixture, "compound_assignment_to_read_only_indexer_still_errors")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauCompoundAssignRecordsPropertyWrite, true};
+
+    CheckResult result = check(R"(
+        type T = { read [string]: number }
+
+        local function f(foo: T, k: string)
+            foo[k] += 5
+        end
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);


### PR DESCRIPTION
## Problem

Compound assignment does not record that its target property is being written to during constraint generation.

For example:

```luau
local function f(x)
    x.h += 1
    return x.h > 2
end
```

incorrectly reports:

```text
Property h of table '{ read h: number }' is read only
```

The equivalent ordinary assignment, `x.h = x.h + 1`, succeeds and infers the property as read write.

## Change

Record property writes performed by compound assignments allowing inferred properties to become read write in the same way as ordinary assignments.

The change is limited to property and index expression targets. Locals and globals remain excluded because compound assignment must not update their typestate.

Because a compound assignment uses the same AST expression for both reading and writing its target the existing read type is preserved while the write constraint is recorded. Genuine read only and write only property violations continue to be reported.

Fixes #2603.

## Testing

Added coverage for:

* Inferring a read write property through compound assignment
* Matching ordinary and compound assignment inference
* Compound assignment with another arithmetic operator
* Compound assignment through an index expression
* Existing mutable properties
* Preserving local variable typestate
* Rejecting writes to read only properties
* Rejecting reads from write only properties
* Rejecting writes through read only indexers

The positive regression tests were verified to be load bearing by temporarily neutralizing only the new write recording path.