### PR TITLE
Fix function not being a valid type for (...any) -> ...any annotations

### DIFF
--- a/Analysis/include/Luau/Subtyping.h
+++ b/Analysis/include/Luau/Subtyping.h
@@ -333,6 +333,12 @@ private:
     SubtypingResult isCovariantWith(SubtypingEnvironment& env, const MetatableType* subMt, const PrimitiveType* superPrim, NotNull<Scope> scope);
     SubtypingResult isCovariantWith(SubtypingEnvironment& env, const TableType* subTable, const PrimitiveType* superPrim, NotNull<Scope> scope);
     SubtypingResult isCovariantWith(SubtypingEnvironment& env, const PrimitiveType* subPrim, const TableType* superTable, NotNull<Scope> scope);
+    SubtypingResult isCovariantWith(
+        SubtypingEnvironment& env,
+        const PrimitiveType* subPrim,
+        const FunctionType* superFunction,
+        NotNull<Scope> scope
+    );
     SubtypingResult isCovariantWith(SubtypingEnvironment& env, const SingletonType* subSingleton, const TableType* superTable, NotNull<Scope> scope);
 
     SubtypingResult isCovariantWith(

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -32,6 +32,7 @@ LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
 LUAU_FASTFLAG(LuauRefactorStringSemanticSubtyping)
 LUAU_FASTFLAGVARIABLE(LuauFixSuperNegationTypePaths)
 LUAU_FASTFLAGVARIABLE(LuauDoNotIceForBindingGeneric)
+LUAU_FASTFLAGVARIABLE(LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction)
 
 
 namespace Luau
@@ -945,6 +946,8 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, TypeId sub
         result.isSubtype = superPrimitive->type == PrimitiveType::Function;
     }
     else if (auto p = get2<FunctionType, FunctionType>(subTy, superTy))
+        result = isCovariantWith(env, p, scope);
+    else if (auto p = get2<PrimitiveType, FunctionType>(subTy, superTy); p && FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction)
         result = isCovariantWith(env, p, scope);
     else if (auto p = get2<TableType, TableType>(subTy, superTy))
     {
@@ -2525,6 +2528,33 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, const Prim
     }
 
     return result;
+}
+
+static bool isVariadicAnyPack(TypePackId tp)
+{
+    auto [head, tail] = flatten(tp);
+
+    if (!head.empty() || !tail)
+        return false;
+
+    const VariadicTypePack* vtp = get<VariadicTypePack>(follow(*tail));
+
+    return vtp && bool(get<AnyType>(follow(vtp->ty)));
+}
+
+SubtypingResult Subtyping::isCovariantWith(
+    SubtypingEnvironment& env,
+    const PrimitiveType* subPrim,
+    const FunctionType* superFunction,
+    NotNull<Scope> scope
+)
+{
+    if (subPrim->type != PrimitiveType::Function)
+        return {false};
+
+    // `function` is the set of all functions, so it can only satisfy a function
+    // type whose parameters and returns are both variadic `any`.
+    return {isVariadicAnyPack(superFunction->argTypes) && isVariadicAnyPack(superFunction->retTypes)};
 }
 
 SubtypingResult Subtyping::isCovariantWith(

--- a/tests/Subtyping.test.cpp
+++ b/tests/Subtyping.test.cpp
@@ -24,6 +24,7 @@ LUAU_FASTFLAG(LuauSubtypingMissingPropertiesAsNil)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
 LUAU_FASTFLAG(LuauNewTypePathErrorMessages)
 LUAU_FASTFLAG(LuauRefactorStringSemanticSubtyping)
+LUAU_FASTFLAG(LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction)
 
 using namespace Luau;
 
@@ -1536,6 +1537,60 @@ TEST_CASE_FIXTURE(SubtypeFixture, "(number, number...) <!: (number, string...)")
     TypePackId rightTp = arena.addTypePack({builtinTypes->numberType}, arena.addTypePack(VariadicTypePack{builtinTypes->stringType}));
 
     CHECK_IS_NOT_SUBTYPE(leftTp, rightTp);
+}
+
+TEST_CASE_FIXTURE(SubtypeFixture, "function_is_a_subtype_of_a_variadic_any_function")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    // function <: (...any) -> ...any
+    TypeId variadicAnyFunction = fn({}, VariadicTypePack{getBuiltins()->anyType}, {}, VariadicTypePack{getBuiltins()->anyType});
+
+    CHECK_IS_SUBTYPE(getBuiltins()->functionType, variadicAnyFunction);
+}
+
+TEST_CASE_FIXTURE(SubtypeFixture, "function_is_not_a_subtype_of_a_function_that_returns_nothing")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    // function <!: (...any) -> ()
+    TypeId superTy = fn({}, VariadicTypePack{getBuiltins()->anyType}, {});
+
+    CHECK_IS_NOT_SUBTYPE(getBuiltins()->functionType, superTy);
+}
+
+TEST_CASE_FIXTURE(SubtypeFixture, "function_is_not_a_subtype_of_a_nullary_function")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    // function <!: () -> ()
+    CHECK_IS_NOT_SUBTYPE(getBuiltins()->functionType, fn({}, {}));
+}
+
+TEST_CASE_FIXTURE(SubtypeFixture, "function_is_not_a_subtype_of_a_concrete_function")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    // function <!: (number) -> string
+    CHECK_IS_NOT_SUBTYPE(getBuiltins()->functionType, fn({getBuiltins()->numberType}, {getBuiltins()->stringType}));
+}
+
+TEST_CASE_FIXTURE(SubtypeFixture, "concrete_function_is_still_a_subtype_of_function")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    // (number) -> string <: function
+    CHECK_IS_SUBTYPE(fn({getBuiltins()->numberType}, {getBuiltins()->stringType}), getBuiltins()->functionType);
+}
+
+TEST_CASE_FIXTURE(SubtypeFixture, "other_primitives_are_not_subtypes_of_a_variadic_any_function")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    TypeId variadicAnyFunction = fn({}, VariadicTypePack{getBuiltins()->anyType}, {}, VariadicTypePack{getBuiltins()->anyType});
+
+    CHECK_IS_NOT_SUBTYPE(getBuiltins()->numberType, variadicAnyFunction);
+    CHECK_IS_NOT_SUBTYPE(getBuiltins()->tableType, variadicAnyFunction);
 }
 
 TEST_CASE_FIXTURE(SubtypeFixture, "subtyping_reasonings_check_for_error_suppression_in_union_type_path")

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -28,6 +28,7 @@ LUAU_FASTFLAG(LuauHigherOrderGenericInference)
 LUAU_FASTFLAG(LuauCallErrorReportingRecoversArgumentLocationsForPacks)
 LUAU_FASTFLAG(LuauRefactorStringSemanticSubtyping)
 LUAU_FASTFLAG(LuauThreadGeneralizeThroughConstraintGeneration)
+LUAU_FASTFLAG(LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -4618,6 +4619,24 @@ TEST_CASE_FIXTURE(Fixture, "let_generalization_multiple_values")
     CHECK_EQ("string", toString(requireType("r2"), {true}));
     CHECK_EQ("number", toString(requireType("r3"), {true}));
     CHECK_EQ("string", toString(requireType("r4"), {true}));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "function_primitive_satisfies_variadic_any_annotation")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+
+    ScopedFastFlag sff{FFlag::LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction, true};
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        type fun = typeof((function()
+            local a: unknown
+            assert(typeof(a) == "function")
+            return a
+        end)())
+
+        local a = (nil :: any) :: fun
+        local b: (...any) -> ...any = a
+    )"));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
## Problem

The `function` primitive represents the set of all function types, but it is not currently accepted as a subtype of the `(...any) -> ...any` annotation:

```luau
(...any) -> ...any
```

This causes valid annotations to be rejected:

```luau
type fun = typeof((function()
    local value: unknown
    assert(typeof(value) == "function")
    return value
end)())

local value: fun = ...
local callable: (...any) -> ...any = value
```

This is distinct from #2656, which was closed as by design. That issue attempted to use `function` as a subtype of specific function signatures, which is unsafe and remains rejected:

| Relation | Result after this change |
| --- | --- |
| `function <: () -> ()` | Rejected |
| `function <: (...any) -> ()` | Rejected |
| `function <: (...any) -> ...any` | Accepted |
| `(number) -> string <: function` | Accepted, unchanged |

Of these, only `(...any) -> ...any` avoids assuming a particular parameter or return shape.

## Change

Add the missing `PrimitiveType` to `FunctionType` subtyping case and accept it only when the target has both an exactly variadic `any` argument pack and an exactly variadic `any` return pack.

This mirrors the existing treatment of the `table` primitive, which is accepted as a subtype of the empty table type `{}` but not more specific table shapes, via a shape check on the supertype rather than error suppression (`Subtyping.cpp:2474`).

The change is guarded by `LuauFunctionPrimitiveIsSubtypeOfVariadicAnyFunction`.

Fixes #2657.

## Testing

Added seven focused tests covering:

- `function` as a subtype of `(...any) -> ...any`
- The end to end reproduction from #2657
- Rejection of `function <: () -> ()`
- Rejection of `function <: (...any) -> ()`
- Rejection of concrete function signatures
- Preserving concrete function subtyping to `function`
- Preventing other primitive types from satisfying `(...any) -> ...any`

The two positive tests were verified to be load bearing by temporarily neutralizing only the new subtyping case. The remaining tests guard unchanged behaviour.