### PR TITLE
luaV_equalval passes t1's metatable twice for TOBJECT __eq

### DIFF
--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -365,7 +365,7 @@ int luaV_equalval(lua_State* L, const TValue* t1, const TValue* t2)
     case LUA_TOBJECT:
     {
         // We follow the same rules as metatables.
-        tm = get_compTM(L, objectvalue(t1)->lclass->instancemetatable, objectvalue(t1)->lclass->instancemetatable, TM_EQ);
+        tm = get_compTM(L, objectvalue(t1)->lclass->instancemetatable, objectvalue(t2)->lclass->instancemetatable, TM_EQ);
         if (!tm)
             return objectvalue(t1) == objectvalue(t2);
         break; // will try TM


### PR DESCRIPTION
The `LUA_TOBJECT` case in `luaV_equalval` passes `t1`'s metatable as both arguments to `get_compTM`, so `t2` is never looked at. The `LUA_TUSERDATA` case just above it uses `t1` and `t2` correctly.

Because both args are t1's metatable, `mt1 == mt2` is always true and `get_compTM` returns t1's `__eq` without checking t2's class. `a == b` between objects of different classes then fires a's `__eq` even when b has none or a different one.

Second arg should be `objectvalue(t2)`. 